### PR TITLE
Fix nested receiver bug

### DIFF
--- a/typesafe-builder-checker/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/typesafe-builder-checker/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -129,6 +129,21 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
   }
 
   /**
+   * Returns whether the return type of the given method invocation tree has an @This annotation
+   * from the Returns Receiver Checker.
+   *
+   * <p>Package-private to permit calls from TypesafeBuilderTransfer.
+   */
+  boolean returnsThis(final MethodInvocationTree tree) {
+    ReturnsRcvrAnnotatedTypeFactory rrATF = getReturnsRcvrAnnotatedTypeFactory();
+    ExecutableElement methodEle = TreeUtils.elementFromUse(tree);
+    AnnotatedTypeMirror methodATm = rrATF.getAnnotatedType(methodEle);
+    AnnotatedTypeMirror rrType =
+        ((AnnotatedTypeMirror.AnnotatedExecutableType) methodATm).getReturnType();
+    return rrType != null && rrType.hasAnnotation(This.class);
+  }
+
+  /**
    * This tree annotator is needed to create types for fluent builders that have @This annotations.
    */
   private class TypesafeBuilderTreeAnnotator extends TreeAnnotator {
@@ -142,14 +157,7 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
 
       // Check to see if the ReturnsReceiver Checker has a @This annotation
       // on the return type of the method
-
-      ReturnsRcvrAnnotatedTypeFactory rrATF = getReturnsRcvrAnnotatedTypeFactory();
-      ExecutableElement methodEle = TreeUtils.elementFromUse(tree);
-      AnnotatedTypeMirror methodATm = rrATF.getAnnotatedType(methodEle);
-      AnnotatedTypeMirror rrType =
-          ((AnnotatedTypeMirror.AnnotatedExecutableType) methodATm).getReturnType();
-
-      if (rrType != null && rrType.hasAnnotation(This.class)) {
+      if (returnsThis(tree)) {
 
         // Fetch the current type of the receiver, or top if none exists
         ExpressionTree receiverTree = TreeUtils.getReceiverTree(tree.getMethodSelect());

--- a/typesafe-builder-checker/tests/autovalue/Animal.java
+++ b/typesafe-builder-checker/tests/autovalue/Animal.java
@@ -71,4 +71,10 @@ abstract class Animal {
     Animal a1 = builder().setName("Jim").setNumberOfLegs(7).build();
     a1.toBuilder().build();
   }
+
+  public static void buildSomethingRightFluentWithLocal() {
+    Builder b = builder();
+    b.setName("Jim").setNumberOfLegs(7);
+    b.build();
+  }
 }


### PR DESCRIPTION
Two changes:
* move the code for checking whether a `MethodInvocationTree` returns an `@This` result into its own method, so I can call it from the Transfer class, and
* fix the nested receiver bug reported in #42 by looping over the receivers of `MethodInvocationNode`s that all have `@This` annotations on their return types until I either reach a call to a method that doesn't return `@This` or a node that isn't a method

Fixes #42.