### PR TITLE
Rename "typesafe builder checker" to "object construction checker"

### DIFF
--- a/README-LOMBOK.md
+++ b/README-LOMBOK.md
@@ -16,8 +16,8 @@ Build the Object Construction Checker:
 ```
 git clone https://github.com/msridhar/returnsrecv-checker.git
 (cd returnsrecv-checker && ./gradlew build && ./gradlew publishToMavenLocal)
-git clone https://github.com/kelloggm/typesafe-builder-checker.git
-(cd typesafe-builder-checker && ./gradlew build && ./gradlew publishToMavenLocal)
+git clone https://github.com/kelloggm/object-construction-checker.git
+(cd object-construction-checker && ./gradlew build && ./gradlew publishToMavenLocal)
 ```
 
 2. Add the [org.checkerframework](https://plugins.gradle.org/plugin/org.checkerframework) Gradle plugin to the `plugins` block of your `build.gradle` file:
@@ -36,12 +36,12 @@ repositories {
     mavenLocal()
 }
 checkerFramework {
-    checkers = ['org.checkerframework.checker.builder.TypesafeBuilderChecker']
+    checkers = ['org.checkerframework.checker.builder.ObjectConstructionChecker']
     extraJavacArgs = ['-AsuppressWarnings=type.anno.before']
 }
 dependencies {
-    checkerFramework 'org.checkerframework:typesafe-builder:0.1-SNAPSHOT'
-    implementation 'org.checkerframework:typesafe-builder-qual:0.1-SNAPSHOT'
+    checkerFramework 'org.checkerframework:object-construction:0.1-SNAPSHOT'
+    implementation 'org.checkerframework:object-construction-qual:0.1-SNAPSHOT'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ There are separate instructions for [using the Object Construction Checker with 
 ```bash
 git clone https://github.com/msridhar/returnsrecv-checker.git
 ./gradlew -p returnsrecv-checker build publishToMavenLocal
-git clone https://github.com/kelloggm/typesafe-builder-checker.git
-./gradlew -p typesafe-builder-checker build publishToMavenLocal
+git clone https://github.com/kelloggm/object-construction-checker.git
+./gradlew -p object-construction-checker build publishToMavenLocal
 ```
 
 2. Make your Maven/Gradle project depend on `org.checkerframework:object-construction:0.1-SNAPSHOT`.

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/builder/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/builder/ObjectConstructionAnnotatedTypeFactory.java
@@ -132,7 +132,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
    * Returns whether the return type of the given method invocation tree has an @This annotation
    * from the Returns Receiver Checker.
    *
-   * <p>Package-private to permit calls from TypesafeBuilderTransfer.
+   * <p>Package-private to permit calls from {@link ObjectConstructionTransfer}.
    */
   boolean returnsThis(final MethodInvocationTree tree) {
     ReturnsRcvrAnnotatedTypeFactory rrATF = getReturnsRcvrAnnotatedTypeFactory();


### PR DESCRIPTION
The package is still `builder` (that is, `org.checkerframework.checker.builder`).
Is it intentional that it was not renamed?