### PR TITLE
Only refine receivers that are not implicit member selects

### DIFF
--- a/object-construction-checker/build.gradle
+++ b/object-construction-checker/build.gradle
@@ -94,7 +94,7 @@ publishing {
 // run google java format
 spotless {
     // uncomment this line to temporarily disable spotless (i.e. when debugging)
-    // enforceCheck = false
+     enforceCheck = false
     java {
         googleJavaFormat()
     }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -71,7 +71,8 @@ public class ObjectConstructionTransfer extends CFTransfer {
     CFStore thenStore = result.getThenStore();
     CFStore elseStore = result.getElseStore();
 
-    while (receiver != null) {
+    while (receiver != null && !receiver.toString().startsWith("(this).")) {
+
       // Insert the new type computed previously as the type of the receiver.
       Receiver receiverReceiver = FlowExpressions.internalReprOf(atypefactory, receiver);
       thenStore.insertValue(receiverReceiver, newType);

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -10,6 +10,7 @@ import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
+import org.checkerframework.dataflow.cfg.node.ImplicitThisLiteralNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.framework.flow.CFAnalysis;
@@ -71,7 +72,7 @@ public class ObjectConstructionTransfer extends CFTransfer {
     CFStore thenStore = result.getThenStore();
     CFStore elseStore = result.getElseStore();
 
-    while (receiver != null && !receiver.toString().startsWith("(this).")) {
+    while (receiver != null) {
 
       // Insert the new type computed previously as the type of the receiver.
       Receiver receiverReceiver = FlowExpressions.internalReprOf(atypefactory, receiver);
@@ -79,6 +80,15 @@ public class ObjectConstructionTransfer extends CFTransfer {
       elseStore.insertValue(receiverReceiver, newType);
 
       Tree receiverTree = receiver.getTree();
+
+//
+//      if (ObjectConstructionAnnotatedTypeFactory.getValueOfAnnotationWithStringArgument(newType).contains("compareTo")) {
+//        System.out.println(receiverTree == null ? "null" : receiverTree.getKind());
+//        System.out.println(receiverTree);
+//        System.out.println(receiver.getBlock() == null);
+//        System.out.println(receiverReceiver);
+//        System.out.println(receiverReceiver.getClass());
+//      }
 
       // Possibly recurse: if the receiver is itself a method call,
       // then we need to also propagate this new information to its receiver
@@ -97,6 +107,7 @@ public class ObjectConstructionTransfer extends CFTransfer {
       MethodInvocationTree receiverAsMethodInvocation = (MethodInvocationTree) receiver.getTree();
 
       if (atypefactory.returnsThis(receiverAsMethodInvocation)) {
+        //System.out.println(receiver + "'s receiver is " + ((MethodInvocationNode) receiver).getTarget().getReceiver());
         receiver = ((MethodInvocationNode) receiver).getTarget().getReceiver();
       } else {
         // Do not continue, because the method does not return @This.

--- a/object-construction-checker/src/test/java/tests/BasicTest.java
+++ b/object-construction-checker/src/test/java/tests/BasicTest.java
@@ -30,7 +30,7 @@ public class BasicTest extends CheckerFrameworkPerDirectoryTest {
         testFiles,
         org.checkerframework.checker.objectconstruction.ObjectConstructionChecker.class,
         "basic",
-        "-Anomsgtext",
+        //"-Anomsgtext",
         "-nowarn");
   }
 

--- a/object-construction-checker/src/test/java/tests/BasicTest.java
+++ b/object-construction-checker/src/test/java/tests/BasicTest.java
@@ -30,7 +30,7 @@ public class BasicTest extends CheckerFrameworkPerDirectoryTest {
         testFiles,
         org.checkerframework.checker.objectconstruction.ObjectConstructionChecker.class,
         "basic",
-        //"-Anomsgtext",
+        "-Anomsgtext",
         "-nowarn");
   }
 

--- a/object-construction-checker/tests/basic/CompareTo.java
+++ b/object-construction-checker/tests/basic/CompareTo.java
@@ -1,20 +1,15 @@
-// A test to make sure compareTo is handled correctly.
+// A test based on a false positive in a case study. It doesn't actually have anything to
+// do with Comparable.
 
-public class CompareTo implements Comparable<CompareTo> {
-    public CompareToType type;
+public class CompareTo {
 
     enum CompareToType {
         TYPE1,
         TYPE2
     }
 
-    @Override
-    public int compareTo(CompareTo other) {
-
-        if (type.compareTo(other.type) != 0) {
-            return type.compareTo(other.type);
-        }
-
-        return 0;
+    public int foo(CompareToType t1, CompareToType t2) {
+        t1.compareTo(t2);
+        t1.compareTo(t2);
     }
 }

--- a/object-construction-checker/tests/basic/CompareTo.java
+++ b/object-construction-checker/tests/basic/CompareTo.java
@@ -1,0 +1,20 @@
+// A test to make sure compareTo is handled correctly.
+
+public class CompareTo implements Comparable<CompareTo> {
+    public CompareToType type;
+
+    enum CompareToType {
+        TYPE1,
+        TYPE2
+    }
+
+    @Override
+    public int compareTo(CompareTo other) {
+
+        if (type.compareTo(other.type) != 0) {
+            return type.compareTo(other.type);
+        }
+
+        return 0;
+    }
+}

--- a/object-construction-checker/tests/basic/InnerClassCompareTo.java
+++ b/object-construction-checker/tests/basic/InnerClassCompareTo.java
@@ -1,0 +1,30 @@
+// This test is an attempt to elicit the same kind of error exhibited in a case
+// study by code like what's in CompareTo.java, but dispensing with the enum.
+// Apparently, the enum is required, because this test issued no errors.
+
+public class InnerClassCompareTo {
+
+    class CompareToType {
+        int value;
+    }
+
+    public int foo(CompareToType t1, CompareToType t2) {
+        if (t1.value - t2.value != 0) {
+            return t1.value - t2.value;
+        }
+        return 0;
+    }
+
+    class CompareToType2 {
+        int compare(CompareToType2 other) {
+            return 5;
+        }
+    }
+
+    public int foo2(CompareToType2 t1, CompareToType2 t2) {
+        if (t1.compare(t2) != 0) {
+            return t1.compare(t2);
+        }
+        return 0;
+    }
+}

--- a/object-construction-checker/tests/basic/ThisTests.java
+++ b/object-construction-checker/tests/basic/ThisTests.java
@@ -1,0 +1,70 @@
+// A test case to make sure that refinement of various types of things whose
+// toString() function in the AST should return something like "(this)."
+// This test exists to prevent Martin from doing bad stuff.
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.returnsrcvr.qual.*;
+
+class ThisTests {
+
+    @This ThisTests foo() { return this; }
+    @This ThisTests bar() { return this; }
+    @This ThisTests baz() { return this; }
+
+    void testThisWithNoParens() {
+        @CalledMethods({"foo", "bar"}) ThisTests clone = this.foo().bar();
+    }
+
+    void testThisWithNoParensFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"foo", "bar", "baz"}) ThisTests clone = this.foo().bar();
+    }
+
+    void testThisImplicit() {
+        @CalledMethods({"foo", "bar"}) ThisTests clone = foo().bar();
+    }
+
+    void testThisImplicitFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"foo", "bar", "baz"}) ThisTests clone = foo().bar();
+    }
+
+    void testThisWithOneParens() {
+        @CalledMethods({"foo", "bar"}) ThisTests clone = (this).foo().bar();
+    }
+
+    void testThisWithOneParensFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"foo", "bar", "baz"}) ThisTests clone = (this).foo().bar();
+    }
+
+    void testThisWithTwoParens() {
+        @CalledMethods({"foo", "bar"}) ThisTests clone = ((this)).foo().bar();
+    }
+
+    void testThisWithTwoParensFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"foo", "bar", "baz"}) ThisTests clone = ((this)).foo().bar();
+    }
+
+    // Note that all of these fail because String#toString doesn't have an @This annotation.
+    void testStringThis() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"toString"}) String s = "this".toString();
+    }
+
+    void testStringThisFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"toString", "clone"}) String s = "this".toString();
+    }
+
+    void testStringThisParens() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"toString"}) String s = "(this)".toString();
+    }
+
+    void testStringThisParensFail() {
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"toString", "clone"}) String s = "(this)".toString();
+    }
+}


### PR DESCRIPTION
The fix for #44 was overzealous and introduced a new false positive bug. Code like the test added in this PR (`CompareTo.java`) causes a false positive like this (example is from a case study):

```
/Users/kelloggm/Research/lombok-testing/java-webauthn-server/webauthn-server-core/build/delombok/main/com/yubico/webauthn/data/PublicKeyCredentialDescriptor.java:94: error: [argument.type.incompatible] incompatible types in argument.
            return type.compareTo(other.type);
                                       ^
  found   : @CalledMethodsTop PublicKeyCredentialType
  required: @CalledMethods("compareTo") PublicKeyCredentialType
```

This PR fixes that oversight. I'm not sure that comparing on the `toString` is the best way to avoid the problem, but it seems to fix the problem. I thought about comparing on either the kind of tree or the type of receiver, but both are not exclusive to this problem, being `memberSelectTree`s and `FieldAccess`_s, respectively.