### PR TITLE
Recognize Lombok builders that have been partially written manually

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -256,7 +256,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
         assert hasAnnotation(nextEnclosingElement, AutoValue.class)
             : "class " + nextEnclosingElement.getSimpleName() + " is missing @AutoValue annotation";
 
-      } else if (hasAnnotation(enclosingElement, "lombok.Generated")
+      } else if ((hasAnnotation(enclosingElement, "lombok.Generated")
+              || hasAnnotation(element, "lombok.Generated"))
           && enclosingElement.getSimpleName().toString().endsWith("Builder")) {
         builderKind = BuilderKind.LOMBOK;
       }


### PR DESCRIPTION
Lombok permits the user to manually write parts of a builder, and generate the rest. When that happens, Lombok doesn't place the `@Generated` annotation on the builder itself, but on the generated methods. This PR adds support for builders in that pattern.