### PR TITLE
Support for NOT operation in @CalledMethodPredicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,19 @@ automatically if it is on your compile classpath (as long as no annotation proce
 
 ## Specifying your code
 
-You can specify your code's contracts (what it expects from clients) by writing type annotations.
-A type annotation is written before a type.  For example, in `@NonEmpty List<@Regex String>`, `@NonEmpty` is a type annotation on `List`, and `@Regex` is a type annotation on `String`.
+The Object Construction Checker works as follows:
+ * It reads method specifications or contracts:  what they require when they are called.
+ * It keeps track of which methods have been called on each object.
+ * It warns if method arguments do not satisfy the method's specification.
+
+Most specifications are automatically inferred by the Object Construction
+Checker.  For example, it determines the specification of `build()` from
+`@Nullable` annotations, among other sources.
+
+You can specify your code's contracts (what it expects from clients) by
+writing type annotations.  A type annotation is written before a type.  For
+example, in `@NonEmpty List<@Regex String>`, `@NonEmpty` is a type
+annotation on `List`, and `@Regex` is a type annotation on `String`.
 
 The two most relevant annotations are:
 <dl>

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ if (somePredicate) {
 }
 
 @CalledMethodsPredicate("! methodA") Object x;
-x = never;        // no warning
-x = oneBranch;    // no warning
-x = bothBranches; // warning
+x = never;        // no warning (methodA was never called)
+x = oneBranch;    // no warning (even though methodA might have been called)
+x = bothBranches; // warning (methodA was definitely called)
 ```
 
 Suppose that exactly one (but not both) of two methods should be called.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Most specifications are automatically inferred by the Object Construction
 Checker.  For example, it determines the specification of `build()` from
 `@Nullable` annotations, among other sources.
 
-You can specify your code's contracts (what it expects from clients) by
+In some cases, you may need to specify your code.  You do so by
 writing type annotations.  A type annotation is written before a type.  For
 example, in `@NonEmpty List<@Regex String>`, `@NonEmpty` is a type
 annotation on `List`, and `@Regex` is a type annotation on `String`.
 
-The two most relevant annotations are:
+The two most important type annotations are:
 <dl>
 <dt>`@CalledMethods(<em>methodname</em>...)`</dt>
 <dd>specifies that a value must have had all the given methods called on it.
@@ -74,7 +74,7 @@ Then the receiver for any call to build() must have had `setX` and `setY` called
 </dd>
 
 <dt>`@CalledMethodsPredicate(<em>logical-expression</em>)`</dt>
-</dd>specifies the required method calls using Java boolean syntax.
+<dd>specifies the required method calls using Java boolean syntax.
 
 For example, the annotation `@CalledMethodsPredicate("x && y || z")` on a type represents
 objects such that:

--- a/README.md
+++ b/README.md
@@ -68,8 +68,36 @@ objects such that:
 </dd>
 </dl>
 
-It is possible to use the `@CalledMethodsPredicate` for unsound bug-finding, rather than
-verification, by using the `!` (NOT) operator.
+To determine if a given `@CalledMethods` annotation is a subtype of an `@CalledMethodsPredicate`
+annotation, use the following procedure:
+1. Let *A* be the set of methods in the `@CalledMethods` annotation.
+2. Let *P* be the predicate of the `@CalledMethodsPredicate` annotation.
+3. For each *x* in *A*, replace all instances of *x* in *P* with *true*.
+4. For every other literal *y* in *P*, replace *y* with *false*.
+5. Evaluate *P*. If *P* is true, then `@CalledMethods(`*A*`)` is a subtype of
+`@CalledMethodsPredicate(`*P*`)`. Otherwise, it is not.
+
+No `@CalledMethodsPredicate` annotation is ever a subtype of another, or of
+any `@CalledMethods` annotation. For this reason,
+users should only write `@CalledMethodsPredicate` annotations on the parameters of
+methods (usually in stub files).
+
+The boolean syntax accepted by `@CalledMethodsPredicate` includes a NOT operator (`!`).
+The annotation `@CalledMethodsPredicate("!x")` means: "it isn't the case that x was
+definitely called" or "x was not called on every possible path" rather than
+"x is not called" or "x was not called on any path." This means that the `!` operator
+is primarily useful for unsound bug-finding rather than verification: it can be used
+to prove that a method was definitely called when it should not have been.
+Similarly, the `!` operator can be used to prove that two methods that ought to be
+mutually exclusive were definitely called together by writing
+`@CalledMethodsPredicate("!(a && b)")`. However, it cannot be used to prove the
+absence of paths on which two mutually-exclusive methods were called.
+
+For more details
+on the syntax accepted by `@CalledMethodsPredicate`, see the documentation for
+the
+[Spring Expression Language (SPEL)](https://docs.spring.io/spring/docs/3.0.x/reference/expressions.html),
+whose parser it uses.
 
 The typechecker also supports (and depends on) the 
 [Returns Receiver Checker](https://github.com/msridhar/returnsrecv-checker), which provides the

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This is helpful when type-checking fluent APIs.
 
 ### Type hierarchy (subtyping)
 
+The top element in the hierarchy is `@CalledMethods({})`.
 In `@CalledMethods` annotations, larger arguments induce types that are
 lower in the type hierarchy.  More formally, let &#8849; represent
 subtyping.  Then

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ The syntax of boolean expressions is that of the [Spring Expression Language (SP
 
 The typechecker also supports (and depends on) the
 [Returns Receiver Checker](https://github.com/msridhar/returnsrecv-checker), which provides the
-`@This` annotation. `@This` on a method return type means that the method returns its receiver;
-this checker uses that information to persist sets of known method calls in fluent APIs.
+`@This` annotation. `@This` on a method return type means that the method returns its receiver.
+The Object Construction Checker uses that information when type-checking fluent APIs.
 
 ### Type hierarchy (subtyping)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ writing type annotations.  A type annotation is written before a type.  For
 example, in `@NonEmpty List<@Regex String>`, `@NonEmpty` is a type
 annotation on `List`, and `@Regex` is a type annotation on `String`.
 
+## Type annotations
+
 The two most important type annotations are:
 <dl>
 <dt>`@CalledMethods(<em>methodname</em>...)`</dt>
@@ -83,19 +85,30 @@ objects such that:
 </dd>
 </dl>
 
-To determine if a given `@CalledMethods` annotation is a subtype of an `@CalledMethodsPredicate`
-annotation, use the following procedure:
-1. Let *A* be the set of methods in the `@CalledMethods` annotation.
-2. Let *P* be the predicate of the `@CalledMethodsPredicate` annotation.
-3. For each *x* in *A*, replace all instances of *x* in *P* with *true*.
-4. For every other literal *y* in *P*, replace *y* with *false*.
-5. Evaluate *P*. If *P* is true, then `@CalledMethods(`*A*`)` is a subtype of
-`@CalledMethodsPredicate(`*P*`)`. Otherwise, it is not.
+The typechecker also supports (and depends on) the
+[Returns Receiver Checker](https://github.com/msridhar/returnsrecv-checker), which provides the
+`@This` annotation. `@This` on a method return type means that the method returns its receiver;
+this checker uses that information to persist sets of known method calls in fluent APIs.
+
+## Type hierarchy (subtyping)
+
+In `@CalledMethods`, larger sets induce types that are lower in the type hierarchy.
+More formally, let &#8849; represent subtyping.  Then
+`@CalledMethods(`*set1*`) T1` &#8849; `@CalledMethods(`*set2*`) T2` if  *set1 &supe; set2* and T1 $#8849; T2.
 
 No `@CalledMethodsPredicate` annotation is ever a subtype of another, or of
 any `@CalledMethods` annotation. For this reason,
 users should only write `@CalledMethodsPredicate` annotations on the parameters of
 methods (usually in stub files).
+
+To determine whether `@CalledMethods(`*M*`)` &&#8849; `@CalledMethodsPredicate(`*P*`)`,
+use the following procedure:
+
+1. For each *x* in *M*, replace all instances of *x* in *P* with *true*.
+2. For every other literal *y* in *P*, replace *y* with *false*.
+3. Evaluate *P* and use its result.
+
+## The `@CalledMethodsPredicate` NOT operator (`!`)
 
 The boolean syntax accepted by `@CalledMethodsPredicate` includes a NOT operator (`!`).
 The annotation `@CalledMethodsPredicate("!x")` means: "it isn't the case that x was
@@ -113,11 +126,6 @@ on the syntax accepted by `@CalledMethodsPredicate`, see the documentation for
 the
 [Spring Expression Language (SPEL)](https://docs.spring.io/spring/docs/3.0.x/reference/expressions.html),
 whose parser it uses.
-
-The typechecker also supports (and depends on) the 
-[Returns Receiver Checker](https://github.com/msridhar/returnsrecv-checker), which provides the
-`@This` annotation. `@This` on a method return type means that the method returns its receiver;
-this checker uses that information to persist sets of known method calls in fluent APIs.
 
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ There are [separate instructions](README-LOMBOK.md) if your project uses Lombok.
 
 1. Build the checker by running the following commands from your shell:
 
-```bash
-git clone https://github.com/msridhar/returnsrecv-checker.git
-./gradlew -p returnsrecv-checker build install
-git clone https://github.com/kelloggm/object-construction-checker.git
-./gradlew -p object-construction-checker build install
-```
+  ```bash
+  git clone https://github.com/msridhar/returnsrecv-checker.git
+  ./gradlew -p returnsrecv-checker build install
+  git clone https://github.com/kelloggm/object-construction-checker.git
+  ./gradlew -p object-construction-checker build install
+  ```
 
 2. Make your Maven/Gradle project depend on `net.sridharan.objectconstruction:object-construction-checker:0.1-SNAPSHOT`.
 Build systems other than Maven and Gradle are not yet supported.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ and
 Programmers can extend it to other builders by writing method
 specifications.
 
+The checker performs *verification* rather than *bug-finding*.  The checker
+might yield a false positive warning when your code is too tricky for it to
+verify (please submit an
+[issue](https://github.com/kelloggm/object-construction-checker/issues) if
+you discover this).  However, if the checker issues no warnings, then you
+have a guarantee that your code supplies all the required information to
+the builder.
+
 
 ## Using the checker
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Object Construction Checker works as follows:
 
 If you use AutoValue or Lombok, most specifications are automatically
 inferred by the Object Construction Checker, from field annotations such as
-`@Nullable` and field types such as `Optional'.
+`@Nullable` and field types such as `Optional`.
 
 In some cases, you may need to specify your code.  You do so by writing
 type annotations.  A type annotation is written before a type.  For

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ Then the receiver for any call to build() must have had `setX` and `setY` called
 </dd>
 
 <dt>`@CalledMethodsPredicate(<em>logical-expression</em>)`</dt>
-</dd>permits the
-programmer to specify the permitted method calls using Java boolean syntax. 
+</dd>specifies the required method calls using Java boolean syntax.
 
 For example, the annotation `@CalledMethodsPredicate("x && y || z")` on a type represents
 objects such that:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ objects such that:
 </dd>
 </dl>
 
+It is possible to use the `@CalledMethodsPredicate` for unsound bug-finding, rather than
+verification, by using the `!` (NOT) operator.
+
 The typechecker also supports (and depends on) the 
 [Returns Receiver Checker](https://github.com/msridhar/returnsrecv-checker), which provides the
 `@This` annotation. `@This` on a method return type means that the method returns its receiver;

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can specify that via the type annotation
 The Object Construction Checker will find some errors.
 It will soundly verify that at least one method is called.
 It will warn if both methods are definitely called.
-However, if will not warn if there are some paths on which both methods are called, and some methods on which only one method is called.
+However, if will not warn if there are some paths on which both methods are called, and some paths on which only one method is called.
 
 
 ## More information

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -530,15 +530,16 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
       if (AnnotationUtils.areSame(superAnno, TOP)) {
         return true;
-      } else if (AnnotationUtils.areSame(subAnno, TOP)) {
-        return false;
       }
 
       if (AnnotationUtils.areSameByClass(subAnno, CalledMethodsPredicate.class)) {
         return false;
       }
 
-      Set<String> subVal = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(subAnno));
+      Set<String> subVal =
+          AnnotationUtils.areSame(subAnno, TOP)
+              ? Collections.emptySet()
+              : new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(subAnno));
 
       if (AnnotationUtils.areSameByClass(superAnno, CalledMethodsPredicate.class)) {
         // superAnno is a CMP annotation, so we need to evaluate the predicate

--- a/object-construction-checker/tests/basic/Not.java
+++ b/object-construction-checker/tests/basic/Not.java
@@ -1,0 +1,61 @@
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+class Not {
+
+    class Foo {
+        void a() {}
+        void b() {}
+        void c() {}
+        void notA(@CalledMethodsPredicate("!a") Foo this) {}
+        void notB(@CalledMethodsPredicate("!b") Foo this) {}
+    }
+
+    void test1(Foo f) {
+        f.notA();
+        f.notB();
+    }
+
+    void test2(Foo f) {
+        f.c();
+        f.notA();
+        f.notB();
+    }
+
+    void test3(Foo f) {
+        f.a();
+        // :: error: method.invocation.invalid
+        f.notA();
+        f.notB();
+    }
+
+    void test4(Foo f) {
+        f.b();
+        f.notA();
+        // :: error: method.invocation.invalid
+        f.notB();
+    }
+
+    void test5(Foo f) {
+        f.a();
+        f.b();
+        // :: error: method.invocation.invalid
+        f.notA();
+        // :: error: method.invocation.invalid
+        f.notB();
+    }
+
+    void callA(Foo f) {
+        f.a();
+    }
+
+    void test6(Foo f) {
+        callA(f);
+        // DEMONSTRATION OF UNSOUNDNESS
+        f.notA();
+    }
+
+    void test7(@CalledMethods("a") Foo f) {
+        // :: error: method.invocation.invalid
+        f.notA();
+    }
+}

--- a/object-construction-checker/tests/basic/Not.java
+++ b/object-construction-checker/tests/basic/Not.java
@@ -58,4 +58,14 @@ class Not {
         // :: error: method.invocation.invalid
         f.notA();
     }
+
+    void test8(Foo f, boolean test) {
+        if (test) {
+            f.a();
+        } else {
+            f.b();
+        }
+        // DEMONSTRATION OF UNSOUNDNESS
+        f.notA();
+    }
 }

--- a/object-construction-checker/tests/basic/Xor.java
+++ b/object-construction-checker/tests/basic/Xor.java
@@ -1,0 +1,63 @@
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+class Xor {
+
+    class Foo {
+        void a() {}
+        void b() {}
+        void c() {}
+        // SPEL doesn't support XOR directly (it represents exponentiation as ^ instead),
+        // so use a standard gate encoding
+        void aXorB(@CalledMethodsPredicate("(a || b) && !(a && b)") Foo this) {}
+    }
+
+    void test1(Foo f) {
+        // :: error: method.invocation.invalid
+        f.aXorB();
+    }
+
+    void test2(Foo f) {
+        f.c();
+        // :: error: method.invocation.invalid
+        f.aXorB();
+    }
+
+    void test3(Foo f) {
+        f.a();
+        f.aXorB();
+    }
+
+    void test4(Foo f) {
+        f.b();
+        f.aXorB();
+    }
+
+    void test5(Foo f) {
+        f.a();
+        f.b();
+        // :: error: method.invocation.invalid
+        f.aXorB();
+    }
+
+    void callA(Foo f) {
+        f.a();
+    }
+
+    void test6(Foo f) {
+        callA(f);
+        f.b();
+        // DEMONSTRATION OF UNSOUNDNESS
+        f.aXorB();
+    }
+
+    void test7(@CalledMethods("a") Foo f) {
+        f.aXorB();
+    }
+
+    void test8(Foo f) {
+        callA(f);
+        // THIS IS AN UNAVOIDABLE FALSE POSITIVE
+        // :: error: method.invocation.invalid
+        f.aXorB();
+    }
+}


### PR DESCRIPTION
Supporting unsound bug-finding was surprisingly easy: the boolean expression parser we were using already supports the not operator, so the only code change I had to make was to changing the `isSubtype` implementation so top is not always assumed to be un-assignable: `@CalledMethodsUnknown` is a subtype of `@CalledMethodsPredicate("!foo")`, for example.

I also added two test cases. XOR isn't natively supported by our parser, but it's easily representable as `(a || b) && !(a && b)`, so that's not too bad.

I also added a note to the README that using the not operator in `CalledMethodsPredicate` makes the checker unsound.