### PR TITLE
Add task to print classpath

### DIFF
--- a/object-construction-checker/build.gradle
+++ b/object-construction-checker/build.gradle
@@ -73,3 +73,9 @@ clean.doFirst {
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")
+
+task printClasspath {
+    doLast {
+        println sourceSets.main.runtimeClasspath.asPath
+    }
+}


### PR DESCRIPTION
This is useful for copy-pasting the path for use with https://github.com/kelloggm/do-like-javac