### PR TITLE
Correct dispatching problem in toBuilder handling

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -325,7 +325,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     Set<String> allBuilderMethodNames = getAllMethodNames(builderElement);
     List<String> requiredProperties = getRequiredProperties(classElement, allBuilderMethodNames, b);
     AnnotationMirror calledMethodsAnno =
-        createCalledMethodsForAutoValueProperties(requiredProperties, allBuilderMethodNames);
+        createCalledMethodsForProperties(requiredProperties, allBuilderMethodNames, b);
     type.replaceAnnotation(calledMethodsAnno);
   }
 


### PR DESCRIPTION
It seems that when I added support for Lombok `toBuilder` code I neglected to change the method called to produce the `@CalledMethods` annotation. This PR fixes that oversight.