### PR TITLE
Allow @This on qualified return type

### DIFF
--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrVisitor.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrVisitor.java
@@ -27,7 +27,10 @@ public class ReturnsRcvrVisitor extends BaseTypeVisitor<ReturnsRcvrAnnotatedType
       TreePath parentPath = currentPath.getParentPath();
       Tree parent = parentPath.getLeaf();
       Tree grandparent = parentPath.getParentPath().getLeaf();
-      boolean isReturnAnnot = parent instanceof ModifiersTree && grandparent instanceof MethodTree;
+      boolean isReturnAnnot =
+          grandparent instanceof MethodTree
+              && (parent.equals(((MethodTree) grandparent).getReturnType())
+                  || parent instanceof ModifiersTree);
       if (!isReturnAnnot) {
         checker.report(Result.failure("invalid.this.location"), node);
       }

--- a/returnsrcvr-checker/src/test/java/tests/AllSystemsTest.java
+++ b/returnsrcvr-checker/src/test/java/tests/AllSystemsTest.java
@@ -9,17 +9,17 @@ import org.junit.runners.Parameterized.Parameters;
 /**
  * Test runner for tests of the Returns Receiver Checker.
  *
- * <p>Tests appear as Java files in the {@code tests/returnsrcvr} folder. To add a new test case,
+ * <p>Tests appear as Java files in the {@code tests/all-systems} folder. To add a new test case,
  * create a Java file in that directory. The file contains "// ::" comments to indicate expected
  * errors and warnings; see
  * https://github.com/typetools/checker-framework/blob/master/checker/tests/README .
  */
-public class ReturnsRcvrTest extends CheckerFrameworkPerDirectoryTest {
-  public ReturnsRcvrTest(List<File> testFiles) {
+public class AllSystemsTest extends CheckerFrameworkPerDirectoryTest {
+  public AllSystemsTest(List<File> testFiles) {
     super(
         testFiles,
         ReturnsRcvrChecker.class,
-        "returnsrcvr",
+        "all-systems",
         "-Anomsgtext",
         "-Astubs=stubs/",
         "-nowarn");
@@ -27,6 +27,6 @@ public class ReturnsRcvrTest extends CheckerFrameworkPerDirectoryTest {
 
   @Parameters
   public static String[] getTestDirs() {
-    return new String[] {"returnsrcvr"};
+    return new String[] {"all-systems"};
   }
 }

--- a/returnsrcvr-checker/tests/returnsrcvr/SimpleTest.java
+++ b/returnsrcvr-checker/tests/returnsrcvr/SimpleTest.java
@@ -53,9 +53,12 @@ class SimpleTest {
     // :: error: invalid.this.location
     @This Object f;
 
-    // this is just to make sure we don't crash for interfaces
     interface I {
+
         Object foo();
+
+        SimpleTest.@This I setBar();
+
     }
 
 }


### PR DESCRIPTION
A method declaration like `SimpleTest.@This I setBar()` should be allowed but before we were incorrectly reporting `invalid.this.location`.

Also, separate out `AllSystemsTests` to allow for running the simple returns receiver tests faster.