### PR TITLE
Add test cases for generics support

### DIFF
--- a/object-construction-checker/tests/basic/Generics.java
+++ b/object-construction-checker/tests/basic/Generics.java
@@ -3,7 +3,7 @@ import org.checkerframework.checker.returnsrcvr.qual.*;
 
 class Generics {
 
-    private <T extends Symbol> T getMember(Class<T> type) {
+    private <@CalledMethods("isStatic") T extends Symbol> T getMember(Class<T> type) {
         T sym = getMember(type);
         if (sym != null && sym.isStatic()) {
             return sym;

--- a/object-construction-checker/tests/basic/Generics.java
+++ b/object-construction-checker/tests/basic/Generics.java
@@ -1,0 +1,19 @@
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.returnsrcvr.qual.*;
+
+class Generics {
+
+    private <T extends Symbol> T getMember(Class<T> type) {
+        T sym = getMember(type);
+        if (sym != null && sym.isStatic()) {
+            return sym;
+        }
+        return null;
+    }
+
+    static interface Symbol {
+
+        boolean isStatic();
+
+    }
+}

--- a/object-construction-checker/tests/basic/Generics.java
+++ b/object-construction-checker/tests/basic/Generics.java
@@ -1,9 +1,34 @@
 import org.checkerframework.checker.objectconstruction.qual.*;
 import org.checkerframework.checker.returnsrcvr.qual.*;
 
+import java.util.List;
+import java.util.ArrayList;
+
 class Generics {
 
-    private <T extends Symbol> T getMember(Class<T> type, boolean b) {
+    static interface Symbol {
+
+        boolean isStatic();
+
+        void finalize(@CalledMethods("isStatic") Symbol this);
+    }
+
+    static List<@CalledMethods("isStatic") Symbol> makeList(Symbol s) {
+        s.isStatic();
+        ArrayList<@CalledMethods("isStatic") Symbol> l = new ArrayList<>();
+        l.add(s);
+        return l;
+    }
+
+    static void useList() {
+        Symbol s = null;
+        for (Symbol t: makeList(s)) {
+            t.finalize();
+        }
+    }
+
+    // reduced from real-world code
+    private <@CalledMethodsTop T extends Symbol> T getMember(Class<T> type, boolean b) {
         if (b) {
             T sym = getMember(type, !b);
             if (sym != null && sym.isStatic()) {
@@ -11,16 +36,12 @@ class Generics {
             }
         } else {
             T sym = getMember(type, b);
-              if (sym != null) {
+            if (sym != null) {
                 return sym;
-              }
+            }
         }
         return null;
     }
 
-    static interface Symbol {
 
-        boolean isStatic();
-
-    }
 }

--- a/object-construction-checker/tests/basic/Generics.java
+++ b/object-construction-checker/tests/basic/Generics.java
@@ -3,10 +3,17 @@ import org.checkerframework.checker.returnsrcvr.qual.*;
 
 class Generics {
 
-    private <@CalledMethods("isStatic") T extends Symbol> T getMember(Class<T> type) {
-        T sym = getMember(type);
-        if (sym != null && sym.isStatic()) {
-            return sym;
+    private <T extends Symbol> T getMember(Class<T> type, boolean b) {
+        if (b) {
+            T sym = getMember(type, !b);
+            if (sym != null && sym.isStatic()) {
+                return sym;
+            }
+        } else {
+            T sym = getMember(type, b);
+              if (sym != null) {
+                return sym;
+              }
         }
         return null;
     }

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
@@ -18,5 +18,4 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@DefaultFor(value = TypeUseLocation.LOWER_BOUND)
 public @interface CalledMethodsTop {}

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
@@ -4,8 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * The top qualifier in the Called Methods type hierarchy. It is equivalent to @CalledMethods({}).
@@ -16,4 +18,5 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
+@DefaultFor(value = TypeUseLocation.LOWER_BOUND)
 public @interface CalledMethodsTop {}

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/CalledMethodsTop.java
@@ -4,10 +4,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
-import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * The top qualifier in the Called Methods type hierarchy. It is equivalent to @CalledMethods({}).


### PR DESCRIPTION
Without the `@DefaultFor` meta-annotation on `@CalledMethodsTop` we get an inscrutable `return.type.incompatible` error for the new `Generics` test.  We ran into a similar issue with the returns receiver checker, and I stole the solution from there.