### PR TITLE
Handle build method not named build() for AutoValue

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -278,7 +278,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
       if (builderKind != BuilderKind.NONE) {
 
-        if ("build".equals(methodName)) {
+        if (isBuilderBuildMethod(element, builderKind, nextEnclosingElement)) {
           // determine the required properties and add a corresponding @CalledMethods annotation
           Set<String> allBuilderMethodNames = getAllBuilderSetterMethodNames(enclosingElement);
           List<String> requiredProperties =
@@ -291,6 +291,19 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
       }
 
       return super.visitExecutable(t, p);
+    }
+
+    private boolean isBuilderBuildMethod(
+        ExecutableElement element, BuilderKind builderKind, Element nextEnclosingElement) {
+      switch (builderKind) {
+        case LOMBOK:
+          return "build".equals(element.getSimpleName().toString());
+        case AUTO_VALUE:
+          // return type should be enclosing AutoValue class
+          return TypesUtils.getTypeElement(element.getReturnType()).equals(nextEnclosingElement);
+        default:
+          throw new RuntimeException("not possible!");
+      }
     }
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -302,7 +302,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
           // return type should be enclosing AutoValue class
           return TypesUtils.getTypeElement(element.getReturnType()).equals(nextEnclosingElement);
         default:
-          throw new RuntimeException("not possible!");
+          throw new RuntimeException("unexpected BuilderKind " + builderKind);
       }
     }
   }

--- a/object-construction-checker/tests/autovalue/NonBuildName.java
+++ b/object-construction-checker/tests/autovalue/NonBuildName.java
@@ -1,0 +1,36 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+
+@AutoValue
+abstract class NonBuildName {
+
+  public abstract String name();
+
+  static Builder builder() {
+    return new AutoValue_NonBuildName.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setName(String name);
+
+    abstract NonBuildName makeIt();
+
+  }
+
+  static void correct() {
+    Builder b = builder();
+    b.setName("Phil");
+    b.makeIt();
+  }
+
+  static void wrong() {
+    Builder b = builder();
+    // :: error: finalizer.invocation.invalid
+    b.makeIt();
+  }
+
+}


### PR DESCRIPTION
The build method for an AutoValue Builder need not be named `build`: https://github.com/google/auto/blob/master/value/userguide/builders-howto.md#build_names

So we now match the build method based on type, not name.