### PR TITLE
Properly handle inherited methods for AutoValue and AutoValue Builder types

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -313,10 +313,10 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   }
 
   /**
-   * Is e a setter for a builder?
+   * Is e a setter for an AutoValue builder?
    *
    * @param member member of builder or one of its supertypes
-   * @param builderElement element for the builder
+   * @param builderElement element for the AutoValue builder
    * @return {@code true} if e is a setter for the builder, {@code false} otherwise
    */
   private boolean isAutoValueBuilderSetter(Element member, Element builderElement) {
@@ -330,6 +330,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     }
     TypeMirror retType = ((ExecutableElement) member).getReturnType();
     if (retType.getKind().equals(TypeKind.TYPEVAR)) {
+      // instantiate the type variable for the Builder class
       retType =
           AnnotatedTypes.asMemberOf(
                   getContext().getTypeUtils(),

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -27,6 +27,11 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import org.checkerframework.checker.objectconstruction.qual.CalledMethods;
 import org.checkerframework.checker.objectconstruction.qual.CalledMethodsBottom;
 import org.checkerframework.checker.objectconstruction.qual.CalledMethodsPredicate;
@@ -313,15 +318,19 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
    *     Immutable type
    */
   private Set<String> getAllBuilderSetterMethodNames(Element builderElement) {
-    return builderElement.getEnclosedElements().stream()
+    return getAllSupertypes((Symbol) builderElement).stream().flatMap(e -> e.getEnclosedElements().stream())
         .filter(
             e -> {
               if (!e.getKind().equals(ElementKind.METHOD)) {
                 return false;
               }
+              Set<Modifier> modifiers = ((ExecutableElement)e).getModifiers();
+              if (modifiers.contains(Modifier.STATIC) || !modifiers.contains(Modifier.ABSTRACT)) {
+                return false;
+              }
               TypeMirror retType = ((ExecutableElement) e).getReturnType();
-              return isGuavaImmutableType(retType)
-                  || TypesUtils.getTypeElement(retType).equals(builderElement);
+              TypeElement typeElement = TypesUtils.getTypeElement(retType);
+              return isGuavaImmutableType(retType) || builderElement.equals(typeElement);
             })
         .map(e -> e.getSimpleName().toString())
         .collect(Collectors.toSet());
@@ -456,39 +465,47 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private List<String> getAutoValueRequiredProperties(
       final Element autoValueClassElement, Set<String> allBuilderMethodNames) {
     List<String> requiredPropertyNames = new ArrayList<>();
-    for (Element member : autoValueClassElement.getEnclosedElements()) {
-      if (member.getKind().equals(ElementKind.METHOD)) {
-        // should be an abstract instance method
-        Set<Modifier> modifiers = member.getModifiers();
-        if (!modifiers.contains(Modifier.STATIC) && modifiers.contains(Modifier.ABSTRACT)) {
-          String name = member.getSimpleName().toString();
-          TypeMirror returnType = ((ExecutableElement) member).getReturnType();
-          if (!IGNORED_METHOD_NAMES.contains(name) && !returnType.getKind().equals(TypeKind.VOID)) {
-            // shouldn't have a nullable return
-            boolean hasNullable =
-                Stream.concat(
-                        elements.getAllAnnotationMirrors(member).stream(),
-                        returnType.getAnnotationMirrors().stream())
-                    .anyMatch(anm -> AnnotationUtils.annotationName(anm).endsWith(".Nullable"));
-            if (hasNullable) {
-              continue;
+    for (Element e: getAllSupertypes((Symbol) autoValueClassElement)) {
+      for (Element member : e.getEnclosedElements()) {
+        if (member.getKind().equals(ElementKind.METHOD)) {
+          // should be an abstract instance method
+          Set<Modifier> modifiers = member.getModifiers();
+          if (!modifiers.contains(Modifier.STATIC) && modifiers.contains(Modifier.ABSTRACT)) {
+            String name = member.getSimpleName().toString();
+            TypeMirror returnType = ((ExecutableElement) member).getReturnType();
+            if (!IGNORED_METHOD_NAMES.contains(name) && !returnType.getKind().equals(TypeKind.VOID)) {
+              // shouldn't have a nullable return
+              boolean hasNullable =
+                  Stream.concat(
+                      elements.getAllAnnotationMirrors(member).stream(),
+                      returnType.getAnnotationMirrors().stream())
+                      .anyMatch(anm -> AnnotationUtils.annotationName(anm).endsWith(".Nullable"));
+              if (hasNullable) {
+                continue;
+              }
+              // if return type of foo() is a Guava Immutable type, not required if there is a builder
+              // method fooBuilder()
+              if (isGuavaImmutableType(returnType)
+                  && allBuilderMethodNames.contains(name + "Builder")) {
+                continue;
+              }
+              // if it's an Optional, the Builder will automatically initialize it
+              if (isOptional(returnType)) {
+                continue;
+              }
+              requiredPropertyNames.add(name);
             }
-            // if return type of foo() is a Guava Immutable type, not required if there is a builder
-            // method fooBuilder()
-            if (isGuavaImmutableType(returnType)
-                && allBuilderMethodNames.contains(name + "Builder")) {
-              continue;
-            }
-            // if it's an Optional, the Builder will automatically initialize it
-            if (isOptional(returnType)) {
-              continue;
-            }
-            requiredPropertyNames.add(name);
           }
         }
       }
+
     }
     return requiredPropertyNames;
+  }
+
+  private List<Element> getAllSupertypes(Symbol symbol) {
+    Types types = Types.instance(((JavacProcessingEnvironment) getProcessingEnv()).getContext());
+    return types.closure(symbol.type).stream().map(t -> t.tsym).collect(Collectors.toList());
   }
 
   private boolean isGuavaImmutableType(TypeMirror returnType) {

--- a/object-construction-checker/tests/autovalue/Inheritance.java
+++ b/object-construction-checker/tests/autovalue/Inheritance.java
@@ -1,0 +1,36 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.returnsrcvr.qual.This;
+
+class Inheritance {
+  static interface Props {
+    String name();
+    abstract class Builder<B extends Builder<B>> {
+      public abstract @This B name(String value);
+    }
+  }
+
+  @AutoValue
+  abstract static class PropHolder implements Props {
+    abstract int size();
+    static Builder builder() {
+      return new AutoValue_Inheritance_PropHolder.Builder();
+    }
+    @AutoValue.Builder
+    public abstract static class Builder extends Props.Builder<Builder> {
+      public abstract Builder size(int value);
+      public abstract PropHolder build();
+    }
+  }
+
+  static void correct() {
+    PropHolder.Builder b = PropHolder.builder();
+    b.name("Manu").size(1).build();
+  }
+
+  static void wrong() {
+    PropHolder.Builder b = PropHolder.builder();
+    // :: error: finalizer.invocation.invalid
+    b.size(1).build();
+  }
+}


### PR DESCRIPTION
See the new `Inheritance` test case.  Before, we would not consider inherited abstract methods when determining required properties or potential setters in a Builder class.  To fix, we now look at abstract methods in all supertypes of `@AutoValue` and `@AutoValue.Builder` classes.