### PR TITLE
Ensure AutoValue build method is abstract

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -299,8 +299,9 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
         case LOMBOK:
           return "build".equals(element.getSimpleName().toString());
         case AUTO_VALUE:
-          // return type should be enclosing AutoValue class
-          return TypesUtils.getTypeElement(element.getReturnType()).equals(nextEnclosingElement);
+          // return type should be enclosing AutoValue class and method should be abstract
+          return element.getModifiers().contains(Modifier.ABSTRACT)
+              && TypesUtils.getTypeElement(element.getReturnType()).equals(nextEnclosingElement);
         default:
           throw new RuntimeException("unexpected BuilderKind " + builderKind);
       }

--- a/object-construction-checker/tests/autovalue/Validation.java
+++ b/object-construction-checker/tests/autovalue/Validation.java
@@ -1,0 +1,44 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+
+@AutoValue
+abstract class Validation {
+
+  public abstract String name();
+
+  static Builder builder() {
+    return new AutoValue_Validation.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setName(String name);
+
+    abstract Validation autoBuild();
+
+    public Validation build(@CalledMethods("setName") Builder this) {
+      Validation v = autoBuild();
+      if (v.name().length() < 5) {
+        throw new RuntimeException("name too short!");
+      }
+      return v;
+    }
+
+  }
+
+  static void correct() {
+    Builder b = builder();
+    b.setName("Phil");
+    b.build();
+  }
+
+  static void wrong() {
+    Builder b = builder();
+    // :: error: finalizer.invocation.invalid
+    b.build();
+  }
+
+}


### PR DESCRIPTION
Sometimes AutoValue Builders have a non-abstract `build` method that does some validation, delegating to some other abstract method (usually named `autoBuild`) for the generated build logic.  We should only add a `@CalledMethods` annotation on the abstract method.