### PR TITLE
Fix error message parsing bug

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -49,24 +49,28 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
       return Collections.emptySet();
     }
 
-    String withoutCMAnno = calledMethodsString.trim().substring("@CalledMethods({".length());
+    String withoutCMAnno = calledMethodsString.trim().substring("@CalledMethods(".length());
     String withoutBaseType = withoutCMAnno.substring(0, withoutCMAnno.lastIndexOf(' '));
-    if (withoutBaseType.length() >= 2) {
-      String[] withQuotes = withoutBaseType.substring(0, withoutBaseType.length() - 2).split(", ");
-      Set<String> result = new HashSet<>();
-      for (String s : withQuotes) {
-        if (s.startsWith("\"")) {
-          s = s.substring(1);
-        }
-        if (s.endsWith("\"")) {
-          s = s.substring(0, s.length() - 1);
-        }
-        result.add(s);
-      }
-      return result;
+    String withoutLastParen = withoutBaseType.substring(0, withoutBaseType.length() - 1);
+    String withoutBraces;
+    if (withoutLastParen.startsWith("{")) {
+      withoutBraces = withoutLastParen.substring(1, withoutLastParen.length() - 1);
     } else {
-      return Collections.emptySet();
+      withoutBraces = withoutLastParen;
     }
+
+    String[] withQuotes = withoutBraces.split(", ");
+    Set<String> result = new HashSet<>();
+    for (String s : withQuotes) {
+      if (s.startsWith("\"")) {
+        s = s.substring(1);
+      }
+      if (s.endsWith("\"")) {
+        s = s.substring(0, s.length() - 1);
+      }
+      result.add(s);
+    }
+    return result;
   }
 
   /**

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -83,11 +83,6 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
       Object[] args = r.getDiagMessages().iterator().next().getArgs();
       String actualReceiverAnnoString = (String) args[1];
       String requiredReceiverAnnoString = (String) args[2];
-
-      System.out.println("constructing a finalizer error message");
-      System.out.println("actual: " + actualReceiverAnnoString);
-      System.out.println("required: " + requiredReceiverAnnoString);
-
       if (actualReceiverAnnoString.contains("@CalledMethods(")
           || actualReceiverAnnoString.contains("@CalledMethodsTop")) {
         Set<String> actualCalledMethods = parseCalledMethods(actualReceiverAnnoString);
@@ -99,11 +94,9 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
             missingMethods.append(s);
             missingMethods.append("() ");
           }
-          System.out.println("missing methods: " + missingMethods);
           theResult = Result.failure("finalizer.invocation.invalid", missingMethods.toString());
         }
       }
-      System.out.println("-----------------");
     }
     super.report(theResult, src);
   }

--- a/object-construction-checker/tests/autovalue/SetInsideBuild.java
+++ b/object-construction-checker/tests/autovalue/SetInsideBuild.java
@@ -1,0 +1,22 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+@AutoValue
+abstract class SetInsideBuild {
+    public abstract String name();
+    public abstract int size();
+    static Builder builder() {
+        return new AutoValue_SetInsideBuild.Builder();
+    }
+    @AutoValue.Builder
+    abstract static class Builder {
+        abstract Builder setName(String name);
+        abstract Builder setSize(int value);
+        abstract SetInsideBuild autoBuild();
+        public SetInsideBuild build(Builder this) {
+            // :: error: finalizer.invocation.invalid
+            return this.setSize(4).autoBuild(); // error here
+        }
+    }
+}


### PR DESCRIPTION
I was stripping quotes from around required methods, but not actual methods, so the String comparison didn't work.

Fixes #99.

The new test case is the one from #99; it doesn't fail before this, since exact error messages aren't checked, but I figured there was no harm in including it. I tested that the new error messages are right by manually inspecting the output.