### PR TITLE
Improve precision of Value Checker enabled AMI sniping mode

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -201,8 +201,17 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
             if (valueType.hasAnnotation(StringVal.class)) {
               AnnotationMirror valueAnno = valueType.getAnnotation(StringVal.class);
               List<String> possibleValues = getValueOfAnnotationWithStringArgument(valueAnno);
-              if (possibleValues.size() == 1 && "owner".equals(possibleValues.get(0))) {
-                return "withOwners";
+              if (possibleValues.size() == 1) {
+                String value = possibleValues.get(0);
+                switch(value) {
+                  case "owner":
+                  case "owner-alias":
+                  case "owner-id":
+                    return "withOwners";
+                  case "image-ids":
+                    return "withImageIds";
+                  default:
+                }
               }
             }
           }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -162,14 +162,15 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   }
 
   /**
-   * Given a tree, returns the method that the tree should be considered as calling. Returns
-   * "withOwners" if the call is {@code withFilters(..., new Filter("owner"), ...)}. Otherwise,
-   * returns its first argument.
+   * Given a tree, returns the method that the tree should be considered as calling.
+   * Returns "withOwners" if the call sets an "owner", "owner-alias", or "owner-id" filter.
+   * Returns "withImageIds" if the call sets an "image-ids" filter.
+   *
    *
    * <p>Package-private to permit calls from {@link ObjectConstructionTransfer}.
    *
-   * @return either the first argument, or "withOwners" if the call is {@code withFilters(..., new
-   *     Filter("owner"), ...)}
+   * @return either the first argument, or "withOwners" or "withImageIds" if the tree is an
+   * equivalent filter addition.
    */
   String adjustMethodNameUsingValueChecker(
       final String methodName, final MethodInvocationTree tree) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -41,6 +41,7 @@ import org.checkerframework.checker.returnsrcvr.ReturnsRcvrChecker;
 import org.checkerframework.checker.returnsrcvr.qual.This;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.common.value.qual.StringVal;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -162,64 +163,90 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   }
 
   /**
-   * Given a tree, returns the method that the tree should be considered as calling.
-   * Returns "withOwners" if the call sets an "owner", "owner-alias", or "owner-id" filter.
-   * Returns "withImageIds" if the call sets an "image-ids" filter.
-   *
+   * Given a tree, returns the method that the tree should be considered as calling. Returns
+   * "withOwners" if the call sets an "owner", "owner-alias", or "owner-id" filter. Returns
+   * "withImageIds" if the call sets an "image-ids" filter.
    *
    * <p>Package-private to permit calls from {@link ObjectConstructionTransfer}.
    *
    * @return either the first argument, or "withOwners" or "withImageIds" if the tree is an
-   * equivalent filter addition.
+   *     equivalent filter addition.
    */
   String adjustMethodNameUsingValueChecker(
       final String methodName, final MethodInvocationTree tree) {
-    if (useValueChecker) {
-      if ("withFilters".equals(methodName)) {
-        for (Tree filterTree : tree.getArguments()) {
-          // Search the arguments to withFilters for a Filter constructor invocation,
-          // passing through as many method invocation trees as needed. This code is searching
-          // for code of the form:
-          // new Filter("owner").withValues("...")
-          while (filterTree != null && filterTree.getKind() == Tree.Kind.METHOD_INVOCATION) {
-            filterTree =
-                TreeUtils.getReceiverTree(((MethodInvocationTree) filterTree).getMethodSelect());
-          }
-          if (filterTree == null) {
-            continue;
-          }
-          if (filterTree.getKind() == Tree.Kind.NEW_CLASS) {
-            ExpressionTree filterConstructorArgument =
-                ((NewClassTree) filterTree).getArguments().get(0);
+    if (!useValueChecker) {
+      return methodName;
+    }
+    if ("withFilters".equals(methodName) || "setFilters".equals(methodName)) {
+      for (Tree filterTree : tree.getArguments()) {
+        // Search the arguments to withFilters for a Filter constructor invocation,
+        // passing through as many method invocation trees as needed. This code is searching
+        // for code of the form:
+        // new Filter("owner").withValues("...")
+        // or code of the form:
+        // new Filter().*.withName("owner").*
 
-            // Once https://github.com/typetools/checker-framework/pull/2726 is merged
-            // and we update to the release with that code, the next few lines should
-            // be replaced with a call to ValueCheckerUtils#getExactStringValue().
+        // Set to non-null iff a call to withName was observed; in that case, this variable's
+        // value is the argument to withName.
+        String withNameArg = null;
+        ValueAnnotatedTypeFactory valueATF = getTypeFactoryOfSubchecker(ValueChecker.class);
 
-            AnnotatedTypeMirror valueType =
-                getTypeFactoryOfSubchecker(ValueChecker.class)
-                    .getAnnotatedType(filterConstructorArgument);
-            if (valueType.hasAnnotation(StringVal.class)) {
-              AnnotationMirror valueAnno = valueType.getAnnotation(StringVal.class);
-              List<String> possibleValues = getValueOfAnnotationWithStringArgument(valueAnno);
-              if (possibleValues.size() == 1) {
-                String value = possibleValues.get(0);
-                switch(value) {
-                  case "owner":
-                  case "owner-alias":
-                  case "owner-id":
-                    return "withOwners";
-                  case "image-ids":
-                    return "withImageIds";
-                  default:
-                }
-              }
+        while (filterTree != null && filterTree.getKind() == Tree.Kind.METHOD_INVOCATION) {
+
+          MethodInvocationTree filterTreeAsMethodInvocation = (MethodInvocationTree) filterTree;
+          String filterMethodName = TreeUtils.methodName(filterTreeAsMethodInvocation).toString();
+          if ("withName".equals(filterMethodName)
+              && filterTreeAsMethodInvocation.getArguments().size() >= 1) {
+            Tree withNameArgTree = filterTreeAsMethodInvocation.getArguments().get(0);
+            withNameArg = getExactStringValue(withNameArgTree, valueATF);
+          }
+
+          filterTree =
+              TreeUtils.getReceiverTree(((MethodInvocationTree) filterTree).getMethodSelect());
+        }
+        if (filterTree == null) {
+          continue;
+        }
+        if (filterTree.getKind() == Tree.Kind.NEW_CLASS) {
+
+          String value;
+          if (withNameArg != null) {
+            value = withNameArg;
+          } else {
+            ExpressionTree constructorArg = ((NewClassTree) filterTree).getArguments().get(0);
+            value = getExactStringValue(constructorArg, valueATF);
+          }
+
+          if (value != null) {
+            switch (value) {
+              case "owner":
+              case "owner-alias":
+              case "owner-id":
+                return "withOwners";
+              case "image-id":
+                return "withImageIds";
+              default:
             }
           }
         }
       }
     }
     return methodName;
+  }
+
+  // Once https://github.com/typetools/checker-framework/pull/2726 is merged
+  // and we update to the release with that code, this method should
+  // be replaced with a call to ValueCheckerUtils#getExactStringValue().
+  private static String getExactStringValue(Tree tree, ValueAnnotatedTypeFactory factory) {
+    AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+    if (valueType.hasAnnotation(StringVal.class)) {
+      AnnotationMirror valueAnno = valueType.getAnnotation(StringVal.class);
+      List<String> possibleValues = getValueOfAnnotationWithStringArgument(valueAnno);
+      if (possibleValues.size() == 1) {
+        return possibleValues.get(0);
+      }
+    }
+    return null;
   }
 
   /**

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -201,8 +201,13 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
             withNameArg = getExactStringValue(withNameArgTree, valueATF);
           }
 
-          filterTree =
-              TreeUtils.getReceiverTree(((MethodInvocationTree) filterTree).getMethodSelect());
+          // Descend into a call to Collections.singletonList()
+          if ("singletonList".equals(filterMethodName)) {
+            filterTree = filterTreeAsMethodInvocation.getArguments().get(0);
+          } else {
+            filterTree =
+                    TreeUtils.getReceiverTree(filterTreeAsMethodInvocation.getMethodSelect());
+          }
         }
         if (filterTree == null) {
           continue;

--- a/object-construction-checker/stubs/DescribeImages.astub
+++ b/object-construction-checker/stubs/DescribeImages.astub
@@ -5,8 +5,8 @@ import org.checkerframework.checker.returnsrcvr.qual.*;
 
 class AmazonEC2 {
     DescribeImagesResult describeImages(
-    // any combination of withX/setX has to be permitted if an owner has been set or an imageId has been set
-    @CalledMethodsPredicate("(withOwners || setOwners) || (withImageIds || setImageIds)")
+    // any combination of withX/setX has to be permitted if an owner has been set or an imageId has been set or an executable user list has been set
+    @CalledMethodsPredicate("(withOwners || setOwners) || (withImageIds || setImageIds) || (withExecutableUsers || setExecutableUsers)")
     DescribeImagesRequest request);
 }
 
@@ -25,4 +25,8 @@ class DescribeImagesRequest {
     @This DescribeImagesRequest withOwners(Collection<String> o);
 
     @This DescribeImagesRequest withImageIds(Collection<String> i);
+
+    @This DescribeImagesRequest withExecutableUsers(String... i);
+
+    @This DescribeImagesRequest withExecutable(Collection<String> f);
 }

--- a/object-construction-checker/tests/cve/Cve.java
+++ b/object-construction-checker/tests/cve/Cve.java
@@ -25,4 +25,9 @@ public class Cve {
         DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
                 .withImageIds("myImageId"));
     }
+
+    public static void correct3(AmazonEC2 client) {
+        DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
+                .withExecutableUsers("myUsers"));
+    }
 }

--- a/object-construction-checker/tests/cve/Cve2.java
+++ b/object-construction-checker/tests/cve/Cve2.java
@@ -3,6 +3,8 @@ import com.amazonaws.services.ec2.model.DescribeImagesResult;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.AmazonEC2;
 
+import java.util.Collections;
+
 // https://nvd.nist.gov/vuln/detail/CVE-2018-15869
 public class Cve2 {
     private static final String IMG_NAME = "some_linux_img";
@@ -27,6 +29,13 @@ public class Cve2 {
     public static void correct2(AmazonEC2 client) {
         DescribeImagesRequest request = new DescribeImagesRequest();
         request.withImageIds("myImageId");
+
+        DescribeImagesResult result = client.describeImages(request);
+    }
+
+    public static void correct3(AmazonEC2 client) {
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.setExecutableUsers(Collections.singletonList("myUser1"));
 
         DescribeImagesResult result = client.describeImages(request);
     }

--- a/object-construction-checker/tests/cve/MorePreciseFilters.java
+++ b/object-construction-checker/tests/cve/MorePreciseFilters.java
@@ -16,7 +16,7 @@ class MorePreciseFilters {
         ec2Client.describeImages(imagesRequest.withFilters(imageFilters)).getImages();
     }
 
-    void withFilterName(AmazonEC2 ec2Client) {
+    void withFilterNameInList(AmazonEC2 ec2Client) {
         DescribeImagesRequest request = new DescribeImagesRequest();
         request.setFilters(Collections.singletonList(
                 new Filter().withName("image-id").withValues("12345")
@@ -30,5 +30,11 @@ class MorePreciseFilters {
                 .withFilters(new Filter("name", Arrays.asList("my_image_name")),
                         new Filter("owner-id", Arrays.asList("12345")));
         DescribeImagesResult result = ec2.describeImages(request);
+    }
+
+    void withName(AmazonEC2 ec2Client) {
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.withFilters(new Filter().withName("image-id").withValues("12345"));
+        DescribeImagesResult result = ec2Client.describeImages(request);
     }
 }

--- a/object-construction-checker/tests/cve/MorePreciseFilters.java
+++ b/object-construction-checker/tests/cve/MorePreciseFilters.java
@@ -1,0 +1,34 @@
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+class MorePreciseFilters {
+    void ownerAliasList(AmazonEC2 ec2Client) {
+        DescribeImagesRequest imagesRequest = new DescribeImagesRequest();
+        List<Filter> imageFilters = new ArrayList<Filter>();
+        imageFilters.add(new Filter().withName("owner-alias").withValues("microsoft"));
+        ec2Client.describeImages(imagesRequest.withFilters(imageFilters)).getImages();
+    }
+
+    void withFilterName(AmazonEC2 ec2Client) {
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.setFilters(Collections.singletonList(
+                new Filter().withName("image-id").withValues("12345")
+        ));
+
+        DescribeImagesResult result = ec2Client.describeImages(request);
+    }
+
+    void withOwnerId(AmazonEC2 ec2) {
+        DescribeImagesRequest request = new DescribeImagesRequest()
+                .withFilters(new Filter("name", Arrays.asList("my_image_name")),
+                        new Filter("owner-id", Arrays.asList("12345")));
+        DescribeImagesResult result = ec2.describeImages(request);
+    }
+}

--- a/object-construction-checker/tests/cve/MorePreciseFilters.java
+++ b/object-construction-checker/tests/cve/MorePreciseFilters.java
@@ -9,12 +9,15 @@ import java.util.Arrays;
 import java.util.ArrayList;
 
 class MorePreciseFilters {
+
+    /* TODO: handle lists
     void ownerAliasList(AmazonEC2 ec2Client) {
         DescribeImagesRequest imagesRequest = new DescribeImagesRequest();
         List<Filter> imageFilters = new ArrayList<Filter>();
         imageFilters.add(new Filter().withName("owner-alias").withValues("microsoft"));
         ec2Client.describeImages(imagesRequest.withFilters(imageFilters)).getImages();
     }
+    */
 
     void withFilterNameInList(AmazonEC2 ec2Client) {
         DescribeImagesRequest request = new DescribeImagesRequest();

--- a/object-construction-checker/tests/cve/SpecialNames.java
+++ b/object-construction-checker/tests/cve/SpecialNames.java
@@ -1,0 +1,52 @@
+// This test ensures that special handling for method
+// names in DescribeImagesRequest isn't used for other
+// classes with the same names.
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.returnsrcvr.qual.*;
+
+class SpecialNames {
+    @This SpecialNames withFilters() { return this; }
+    void setFilters() {}
+    @This SpecialNames withFilters(SpecialNames f) { return this; }
+    void setFilters(SpecialNames f) {}
+    @This SpecialNames withName() { return this; }
+    @This SpecialNames withName(String f) { return this; }
+
+    SpecialNames() {
+
+    }
+
+    SpecialNames(String x) {
+
+    }
+
+    static void test(SpecialNames s) {
+        // :: error: assignment.type.incompatible
+        @CalledMethods("withOwners") SpecialNames x = s.withFilters(new SpecialNames().withName("owner"));
+    }
+
+    static void test2(SpecialNames s) {
+        s.setFilters(new SpecialNames("owner"));
+        // :: error: assignment.type.incompatible
+        @CalledMethods("withOwners") SpecialNames x = s;
+    }
+
+    static void test3(SpecialNames s) {
+        // :: error: assignment.type.incompatible
+        @CalledMethods("withOwners") SpecialNames x = s.withFilters(new SpecialNames().withName("owner"));
+    }
+
+    static void test4(SpecialNames s) {
+        s.setFilters(new SpecialNames("owner"));
+        // :: error: assignment.type.incompatible
+        @CalledMethods("withOwners") SpecialNames x = s;
+    }
+
+    static void testForCrashes(SpecialNames s) {
+        s.setFilters();
+        s.withFilters();
+
+        s.setFilters(new SpecialNames().withName());
+    }
+}


### PR DESCRIPTION
This PR improves the precision of the `useValueChecker` option when used for AMI sniping detection. In particular, it makes the following improvements, each of which is based on a real false positive we have encountered:
* add `setExecutableUsers` and `withExecutableUsers` to the whitelist in the stub file
* add three new permitted filters: `image-id`, `owner-alias`, `owner-id`
* treat calls to `withName` as the same as using the filter constructor
* introspect into calls to `Collections.singletonList` and examine their arguments