### PR TITLE
Remove auto-discovery manifest file

### DIFF
--- a/object-construction-checker/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/object-construction-checker/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-org.checkerframework.checker.objectconstruction.ObjectConstructionChecker


### PR DESCRIPTION
Now that we instruct users to use the Checker Framework Gradle plugin, this is no longer necessary.  It also makes us more consistent with standard checkers, which typically do not include this manifest.

@kelloggm @mernst question.  For users on build systems other than Gradle, one thing we could do is create a separate `object-construction-auto-discover` artifact that *only* includes the manifest file.  That way, they could run via auto-discovery just by including an extra dependence on that new artifact, without needing special build system integration.  Thoughts?