### PR TITLE
Don't fail when we can't find an AutoValue Builder setter method

### DIFF
--- a/object-construction-checker/build.gradle
+++ b/object-construction-checker/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation "com.google.auto.value:auto-value-annotations:${versions.autoValue}"
     testCompile "com.google.auto.value:auto-value-annotations:${versions.autoValue}"
     testCompile "com.google.auto.value:auto-value:${versions.autoValue}"
+    testCompile "com.ryanharter.auto.value:auto-value-parcel:0.2.7"
 
     // For Lombok Builders
     testCompile "org.projectlombok:lombok:${versions.lombok}"

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -680,6 +681,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     String[] calledMethodNames =
         propertyNames.stream()
             .map(prop -> autoValuePropToBuilderSetterName(prop, avBuilderSetterNames))
+            .filter(Objects::nonNull)
             .toArray(String[]::new);
     return createCalledMethods(calledMethodNames);
   }
@@ -840,12 +842,11 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
       }
     }
 
-    // nothing worked
-    throw new RuntimeException(
-        "could not find Builder setter name for property "
-            + prop
-            + " all names "
-            + builderSetterNames);
+    // Could not find a corresponding setter.  This is likely because an AutoValue Extension is in
+    // use.
+    // See https://github.com/kelloggm/object-construction-checker/issues/110
+    // Until that bug is fixed, we should not have a hard failure here.  Return null instead.
+    return null;
   }
 
   /**

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -843,9 +843,9 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     }
 
     // Could not find a corresponding setter.  This is likely because an AutoValue Extension is in
-    // use.
-    // See https://github.com/kelloggm/object-construction-checker/issues/110
-    // Until that bug is fixed, we should not have a hard failure here.  Return null instead.
+    // use.  See https://github.com/kelloggm/object-construction-checker/issues/110
+    // For now we return null, but once that bug is fixed, this should be changed to an assertion
+    // failure.
     return null;
   }
 

--- a/object-construction-checker/tests/autovalue/FooParcelable.java
+++ b/object-construction-checker/tests/autovalue/FooParcelable.java
@@ -1,0 +1,36 @@
+import com.google.auto.value.AutoValue;
+import android.os.Parcelable;
+
+/**
+ * Adapted from the standard AutoValue example code:
+ * https://github.com/google/auto/blob/master/value/userguide/builders.md
+ */
+@AutoValue
+abstract class FooParcelable implements Parcelable {
+  abstract String name();
+
+  static Builder builder() {
+    return new AutoValue_FooParcelable.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setName(String value);
+
+    abstract FooParcelable build();
+  }
+
+  public static void buildSomethingWrong() {
+    Builder b = builder();
+    // :: error: finalizer.invocation.invalid
+    b.build();
+  }
+
+  public static void buildSomethingRight() {
+    Builder b = builder();
+    b.setName("Frank");
+    b.build();
+  }
+
+}

--- a/object-construction-checker/tests/autovalue/FooParcelable.java
+++ b/object-construction-checker/tests/autovalue/FooParcelable.java
@@ -2,8 +2,7 @@ import com.google.auto.value.AutoValue;
 import android.os.Parcelable;
 
 /**
- * Adapted from the standard AutoValue example code:
- * https://github.com/google/auto/blob/master/value/userguide/builders.md
+ * Test for support of AutoValue Parcel extension
  */
 @AutoValue
 abstract class FooParcelable implements Parcelable {

--- a/object-construction-checker/tests/autovalue/FooParcelable.java
+++ b/object-construction-checker/tests/autovalue/FooParcelable.java
@@ -2,7 +2,9 @@ import com.google.auto.value.AutoValue;
 import android.os.Parcelable;
 
 /**
- * Test for support of AutoValue Parcel extension
+ * Test for support of AutoValue Parcel extension.  This test currently passes, but only because we ignore cases
+ * where we cannot find a matching setter for a method we think corresponds to an AutoValue property.
+ * See https://github.com/kelloggm/object-construction-checker/issues/110
  */
 @AutoValue
 abstract class FooParcelable implements Parcelable {

--- a/object-construction-checker/tests/autovalue/Parcel.java
+++ b/object-construction-checker/tests/autovalue/Parcel.java
@@ -1,0 +1,12 @@
+package android.os;
+
+/**
+ * stub to avoid bringing in Android dependence
+ */
+public final class Parcel {
+
+  public String readString() { return ""; }
+
+  public void writeString(String val) {}
+  
+}

--- a/object-construction-checker/tests/autovalue/Parcelable.java
+++ b/object-construction-checker/tests/autovalue/Parcelable.java
@@ -1,0 +1,17 @@
+package android.os;
+
+/**
+ * stub to avoid bringing in Android dependence
+ */
+public interface Parcelable {
+  public interface Creator<T> {
+
+    public T createFromParcel(Parcel source);
+
+    public T[] newArray(int size);
+  }
+
+  public int describeContents();
+
+  public void writeToParcel(Parcel dest, int flags);
+}


### PR DESCRIPTION
Before, we would fail with a `RuntimeException` if we couldn't match what we thought was an AutoValue property to a corresponding setter in the builder.  But, we don't currently handle AutoValue extension (see #110), and adding full and proper handling will be pretty non-trivial.  So, instead of failing for these cases, just tolerate them.

Add a test case using the AutoValue Parcel extension to expose the problem, along with some stub Android classes so we don't need to pull in a full Android dependence.