### PR TITLE
Load qualifiers for type systems explicitly

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -446,7 +446,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
   @Override
   protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-    return getBundledTypeQualifiersWithPolyAll(
+    return getBundledTypeQualifiers(
         CalledMethods.class,
         CalledMethodsBottom.class,
         CalledMethodsPredicate.class,

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -446,7 +446,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
   @Override
   protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-    return getBundledTypeQualifiersWithoutPolyAll(
+    return getBundledTypeQualifiersWithPolyAll(
         CalledMethods.class,
         CalledMethodsBottom.class,
         CalledMethodsPredicate.class,

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -444,6 +444,15 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     return element.getAnnotation(annotClass) != null;
   }
 
+  @Override
+  protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+    return getBundledTypeQualifiersWithoutPolyAll(
+        CalledMethods.class,
+        CalledMethodsBottom.class,
+        CalledMethodsPredicate.class,
+        CalledMethodsTop.class);
+  }
+
   private boolean hasAnnotation(Element element, String annotName) {
     return element.getAnnotationMirrors().stream()
         .anyMatch(anm -> AnnotationUtils.areSameByName(anm, annotName));

--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
@@ -1,9 +1,8 @@
 package org.checkerframework.checker.returnsrcvr;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
-import com.google.auto.value.AutoValue;
-import java.lang.annotation.Annotation;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementKind;
@@ -11,9 +10,6 @@ import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.checker.framework.AutoValueSupport;
 import org.checkerframework.checker.framework.FrameworkSupport;
 import org.checkerframework.checker.framework.LombokSupport;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.returnsrcvr.qual.BottomThis;
 import org.checkerframework.checker.returnsrcvr.qual.MaybeThis;
 import org.checkerframework.checker.returnsrcvr.qual.This;
@@ -47,7 +43,7 @@ public class ReturnsRcvrAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
   @Override
   protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-    return getBundledTypeQualifiersWithPolyAll(BottomThis.class, MaybeThis.class, This.class);
+    return getBundledTypeQualifiers(BottomThis.class, MaybeThis.class, This.class);
   }
 
   @Override

--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
@@ -1,13 +1,26 @@
 package org.checkerframework.checker.returnsrcvr;
 
+<<<<<<< HEAD
 import java.util.ArrayList;
 import java.util.Collection;
+=======
+import com.google.auto.value.AutoValue;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+>>>>>>> 7c5d9e9... hack to get around qualifier loading issue
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+<<<<<<< HEAD
 import org.checkerframework.checker.framework.AutoValueSupport;
 import org.checkerframework.checker.framework.FrameworkSupport;
 import org.checkerframework.checker.framework.LombokSupport;
+=======
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.checkerframework.checker.returnsrcvr.qual.BottomThis;
+>>>>>>> 7c5d9e9... hack to get around qualifier loading issue
 import org.checkerframework.checker.returnsrcvr.qual.MaybeThis;
 import org.checkerframework.checker.returnsrcvr.qual.This;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
@@ -36,6 +49,11 @@ public class ReturnsRcvrAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     // we have to call this explicitly
     this.postInit();
+  }
+
+  @Override
+  protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+    return getBundledTypeQualifiersWithoutPolyAll(BottomThis.class, MaybeThis.class, This.class);
   }
 
   @Override

--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
@@ -47,7 +47,7 @@ public class ReturnsRcvrAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
   @Override
   protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-    return getBundledTypeQualifiersWithoutPolyAll(BottomThis.class, MaybeThis.class, This.class);
+    return getBundledTypeQualifiersWithPolyAll(BottomThis.class, MaybeThis.class, This.class);
   }
 
   @Override

--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
@@ -1,26 +1,20 @@
 package org.checkerframework.checker.returnsrcvr;
 
-<<<<<<< HEAD
 import java.util.ArrayList;
 import java.util.Collection;
-=======
 import com.google.auto.value.AutoValue;
 import java.lang.annotation.Annotation;
 import java.util.Set;
->>>>>>> 7c5d9e9... hack to get around qualifier loading issue
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
-<<<<<<< HEAD
 import org.checkerframework.checker.framework.AutoValueSupport;
 import org.checkerframework.checker.framework.FrameworkSupport;
 import org.checkerframework.checker.framework.LombokSupport;
-=======
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.returnsrcvr.qual.BottomThis;
->>>>>>> 7c5d9e9... hack to get around qualifier loading issue
 import org.checkerframework.checker.returnsrcvr.qual.MaybeThis;
 import org.checkerframework.checker.returnsrcvr.qual.This;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;


### PR DESCRIPTION
Workaround for typetools/checker-framework#2893.  In some cases we have seen that the code to load qualifiers using reflection does not work, so list them explicitly as a fallback.