### PR TITLE
Re-add auto-discovery manifest file

### DIFF
--- a/object-construction-checker/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/object-construction-checker/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.checkerframework.checker.objectconstruction.ObjectConstructionChecker


### PR DESCRIPTION
This reverts #105.  Upon further thought, it seems best to keep this auto-dismanifest with the checker as long as it is living as its own artifact.  It would only cause a problem if someone included the checker in their build / processor path but didn't want to run it, and that scenario seems unlikely.  In #105 we discussed keeping the manifest in a separate artifact, but that seems like unnecessary complexity at this point.