### PR TITLE
add *very* simple subtyping check for pairs of @CalledMethodsPredicate annotations

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -420,6 +420,15 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
       }
 
       if (AnnotationUtils.areSameByClass(subAnno, CalledMethodsPredicate.class)) {
+        if (AnnotationUtils.areSameByClass(superAnno, CalledMethodsPredicate.class)) {
+          // Permit this only if the predicates are identical, to avoid complicated
+          // predicate equivalence calculation. Good enough in practice.
+          String predicate1 =
+              AnnotationUtils.getElementValue(superAnno, "value", String.class, false);
+          String predicate2 =
+              AnnotationUtils.getElementValue(subAnno, "value", String.class, false);
+          return predicate1.equals(predicate2);
+        }
         return false;
       }
 

--- a/object-construction-checker/tests/basic/CmPredicate.java
+++ b/object-construction-checker/tests/basic/CmPredicate.java
@@ -159,12 +159,22 @@ class CmPredicate {
         m1.f();
     }
 
-    private class MyClass {
+    private static class MyClass {
         void a() { }
         void b() { }
         void c(@CalledMethodsPredicate("a || b") MyClass this) { }
         void d(@CalledMethodsPredicate("a && b") MyClass this) { }
         void e(@CalledMethodsPredicate("a || (b && c)") MyClass this) { }
         void f(@CalledMethodsPredicate("a && b || c") MyClass this) { }
+
+        static void testAssignability1(@CalledMethodsPredicate("a || b") MyClass cAble) {
+            cAble.c();
+            // :: error: method.invocation.invalid
+            cAble.d();
+            // :: error: method.invocation.invalid
+            cAble.e();
+            // :: error: method.invocation.invalid
+            cAble.f();
+        }
     }
 }


### PR DESCRIPTION
I think I did this when I ran the original set of AMI sniping experiments last June, but never committed it (for some reason?). This modifies the tool to match the paper, which I must have written remembering this change (but not that I'd failed to commit it!):

> @CalledMethodsPredicate(P) ⊑ @CalledMethodsPredicate(P)
> Return true: every type is ⊑ itself.