### PR TITLE
Implement getDummyAssignedTo for better generic type inference

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -17,7 +17,10 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.framework.FrameworkSupportUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.framework.AutoValueSupport;
 import org.checkerframework.checker.objectconstruction.framework.FrameworkSupport;
 import org.checkerframework.checker.objectconstruction.framework.LombokSupport;
@@ -479,5 +482,21 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private boolean hasAnnotation(Element element, String annotName) {
     return element.getAnnotationMirrors().stream()
         .anyMatch(anm -> AnnotationUtils.areSameByName(anm, annotName));
+  }
+
+  /**
+   * Returns the annotation type mirror for the type of {@code expressionTree} with default
+   * annotations applied. As types relevant to object construction checking are rarely used inside
+   * generics, this is typically the best choice for type inference.
+   */
+  @Override
+  public @Nullable AnnotatedTypeMirror getDummyAssignedTo(ExpressionTree expressionTree) {
+    TypeMirror type = TreeUtils.typeOf(expressionTree);
+    if (type.getKind() != TypeKind.VOID) {
+      AnnotatedTypeMirror atm = type(expressionTree);
+      addDefaultAnnotations(atm);
+      return atm;
+    }
+    return null;
   }
 }

--- a/object-construction-checker/tests/basic/Generics.java
+++ b/object-construction-checker/tests/basic/Generics.java
@@ -1,8 +1,10 @@
 import org.checkerframework.checker.objectconstruction.qual.*;
 import org.checkerframework.checker.returnsrcvr.qual.*;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.stream.Stream;
 
 class Generics {
 
@@ -43,5 +45,12 @@ class Generics {
         return null;
     }
 
+    static Stream<String> stringList() {
+        String s = "hi";
+        // dummy method call
+        s.contains("h");
+        // should infer type Stream<@CalledMethodsTop String>
+        return Arrays.asList(s).stream();
+    }
 
 }


### PR DESCRIPTION
Since the type qualifier of a generic type parameter should nearly always be `@CalledMethodsTop`, bias type inference in that direction by overriding `getDummyAssignedTo()`.  See additional generics test for a case where this change matters, and previously we would get a spurious error due to inferring a too-specific type.  See also typetools/checker-framework#2686