### PR TITLE
Allow @This annotation in cast expressions

### DIFF
--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrVisitor.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrVisitor.java
@@ -4,6 +4,7 @@ import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
 import com.sun.source.util.TreePath;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -31,7 +32,10 @@ public class ReturnsRcvrVisitor extends BaseTypeVisitor<ReturnsRcvrAnnotatedType
           grandparent instanceof MethodTree
               && (parent.equals(((MethodTree) grandparent).getReturnType())
                   || parent instanceof ModifiersTree);
-      if (!isReturnAnnot) {
+      boolean isCastAnnot =
+          grandparent instanceof TypeCastTree
+              && parent.equals(((TypeCastTree) grandparent).getType());
+      if (!(isReturnAnnot || isCastAnnot)) {
         checker.report(Result.failure("invalid.this.location"), node);
       }
     }

--- a/returnsrcvr-checker/tests/returnsrcvr/GenericReturn.java
+++ b/returnsrcvr-checker/tests/returnsrcvr/GenericReturn.java
@@ -1,0 +1,34 @@
+import org.checkerframework.checker.returnsrcvr.qual.This;
+
+public class GenericReturn {
+
+    abstract static class Builder<B extends Builder<?>> {
+        abstract @This B setFoo(String foo);
+
+        @SuppressWarnings("unchecked")
+        @This B retThis() {
+            return (@This B) this;
+        }
+
+        @This B dontRetThis() {
+            // :: error: return.type.incompatible
+            return null;
+        }
+    }
+
+    static class Builder1 extends Builder<Builder1> {
+
+        @This Builder1 setFoo(String foo) {
+            return this;
+        }
+    }
+
+    static class Builder2 extends Builder<Builder2> {
+
+        @This Builder2 setFoo(String foo) {
+            // :: error: return.type.incompatible
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
We have a real-world example involving generics where we need to write `@This` in a typecast to get the code to type check.  A reduced test case is included.