### PR TITLE
Alias old annotations to fully support Lombok's `checkerframework = true` option

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -19,6 +19,8 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+
+import org.checkerframework.checker.builder.qual.ReturnsReceiver;
 import org.checkerframework.checker.framework.FrameworkSupportUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.framework.AutoValueSupport;
@@ -164,7 +166,19 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     AnnotatedTypeMirror methodATm = rrATF.getAnnotatedType(methodEle);
     AnnotatedTypeMirror rrType =
         ((AnnotatedTypeMirror.AnnotatedExecutableType) methodATm).getReturnType();
-    return rrType != null && rrType.hasAnnotation(This.class);
+    if (rrType != null && rrType.hasAnnotation(This.class)) {
+      return true;
+    } else {
+      return hasOldReturnsReceiverAnnotation(tree);
+    }
+  }
+
+  /**
+   * Continue to trust but not check the old {@link org.checkerframework.checker.builder.qual.ReturnsReceiver}
+   * annotation, for backwards-compatibility.
+   */
+  private boolean hasOldReturnsReceiverAnnotation(MethodInvocationTree tree) {
+    return this.getDeclAnnotation(TreeUtils.elementFromUse(tree), ReturnsReceiver.class) != null;
   }
 
   /**

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -19,7 +19,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-
 import org.checkerframework.checker.builder.qual.ReturnsReceiver;
 import org.checkerframework.checker.framework.FrameworkSupportUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -71,16 +70,18 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private Collection<FrameworkSupport> frameworkSupports;
 
   /**
-   * Lombok has a flag to generate @CalledMethods annotations, but they used the old package name, so
-   * we maintain it as an alias.
+   * Lombok has a flag to generate @CalledMethods annotations, but they used the old package name,
+   * so we maintain it as an alias.
    */
-  private final static String OLD_CALLED_METHODS = "org.checkerframework.checker.builder.qual.CalledMethods";
+  private static final String OLD_CALLED_METHODS =
+      "org.checkerframework.checker.builder.qual.CalledMethods";
 
   /**
-   * Lombok also generates an @NotCalledMethods annotation, which we have no support for. We therefore
-   * treat it as top.
+   * Lombok also generates an @NotCalledMethods annotation, which we have no support for. We
+   * therefore treat it as top.
    */
-  private final static String OLD_NOT_CALLED_METHODS = "org.checkerframework.checker.builder.qual.NotCalledMethods";
+  private static final String OLD_NOT_CALLED_METHODS =
+      "org.checkerframework.checker.builder.qual.NotCalledMethods";
 
   /**
    * Default constructor matching super. Should be called automatically.
@@ -174,8 +175,9 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   }
 
   /**
-   * Continue to trust but not check the old {@link org.checkerframework.checker.builder.qual.ReturnsReceiver}
-   * annotation, for backwards-compatibility.
+   * Continue to trust but not check the old {@link
+   * org.checkerframework.checker.builder.qual.ReturnsReceiver} annotation, for
+   * backwards-compatibility.
    */
   private boolean hasOldReturnsReceiverAnnotation(MethodInvocationTree tree) {
     return this.getDeclAnnotation(TreeUtils.elementFromUse(tree), ReturnsReceiver.class) != null;

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -69,6 +69,18 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private Collection<FrameworkSupport> frameworkSupports;
 
   /**
+   * Lombok has a flag to generate @CalledMethods annotations, but they used the old package name, so
+   * we maintain it as an alias.
+   */
+  private final static String OLD_CALLED_METHODS = "org.checkerframework.checker.builder.qual.CalledMethods";
+
+  /**
+   * Lombok also generates an @NotCalledMethods annotation, which we have no support for. We therefore
+   * treat it as top.
+   */
+  private final static String OLD_NOT_CALLED_METHODS = "org.checkerframework.checker.builder.qual.NotCalledMethods";
+
+  /**
    * Default constructor matching super. Should be called automatically.
    *
    * @param checker the checker associated with this type factory
@@ -97,6 +109,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     this.useValueChecker = checker.hasOption(ObjectConstructionChecker.USE_VALUE_CHECKER);
     this.collectionsSingletonList =
         TreeUtils.getMethod("java.util.Collections", "singletonList", 1, getProcessingEnv());
+    addAliasedAnnotation(OLD_CALLED_METHODS, CalledMethods.class, true);
+    addAliasedAnnotation(OLD_NOT_CALLED_METHODS, TOP);
     this.postInit();
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -167,11 +167,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     AnnotatedTypeMirror methodATm = rrATF.getAnnotatedType(methodEle);
     AnnotatedTypeMirror rrType =
         ((AnnotatedTypeMirror.AnnotatedExecutableType) methodATm).getReturnType();
-    if (rrType != null && rrType.hasAnnotation(This.class)) {
-      return true;
-    } else {
-      return hasOldReturnsReceiverAnnotation(tree);
-    }
+    return (rrType != null && rrType.hasAnnotation(This.class))
+        || hasOldReturnsReceiverAnnotation(tree);
   }
 
   /**

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -121,7 +121,7 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
         "This finalizer cannot be invoked, because the following methods have not been called: %s\n");
     messages.setProperty(
         "predicate.invalid",
-        "An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S → method name | (S) | S && S | S || S. The message from the evaluator was: %s \\n");
+        "An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S --> method name | (S) | S && S | S || S. The message from the evaluator was: %s \\n");
     return messages;
   }
 }

--- a/object-construction-checker/tests/lombok/CheckerFrameworkBuilder.java
+++ b/object-construction-checker/tests/lombok/CheckerFrameworkBuilder.java
@@ -8,7 +8,8 @@ class CheckerFrameworkBuilder {
      * with the exception of the following lines until the next long comment. I have made one change outside
      * the scope of these comments:
      *  - I fixed the placement of the type annotations, which were originally on scoping constructs.
-     *  I think this is a bug in the delombok pretty-printer.
+     *  I think this is a bug in the delombok pretty-printer used to generate this code, but I wasn't
+     *  able to find the configuration options used to reproduce it in the public release.
      *
      * This test represents exactly the code that Lombok generates with the checkerframework = True
      * option in a lombok.config file, including the weird package names they use for the CF and the
@@ -26,6 +27,15 @@ class CheckerFrameworkBuilder {
     public static void testOldCalledMethodsBad(@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y"}) CheckerFrameworkBuilderBuilder pb) {
         // :: error: finalizer.invocation.invalid
         pb.build(); // pb requires y, z
+    }
+
+    public static void testOldRRGood() {
+        CheckerFrameworkBuilder b = CheckerFrameworkBuilder.builder().y(5).z(6).build();
+    }
+
+    public static void testOldRRBad() {
+        // :: error: finalizer.invocation.invalid
+        CheckerFrameworkBuilder b = CheckerFrameworkBuilder.builder().z(6).build(); // also needs to call y
     }
 
     /**

--- a/object-construction-checker/tests/lombok/CheckerFrameworkBuilder.java
+++ b/object-construction-checker/tests/lombok/CheckerFrameworkBuilder.java
@@ -1,0 +1,139 @@
+// skip-idempotent
+import java.util.List;
+class CheckerFrameworkBuilder {
+
+    /**
+     * Most of this test was copied from
+     * https://raw.githubusercontent.com/rzwitserloot/lombok/master/test/transform/resource/after-delombok/CheckerFrameworkBuilder.java
+     * with the exception of the following lines until the next long comment. I have made one change outside
+     * the scope of these comments:
+     *  - I fixed the placement of the type annotations, which were originally on scoping constructs.
+     *  I think this is a bug in the delombok pretty-printer.
+     *
+     * This test represents exactly the code that Lombok generates with the checkerframework = True
+     * option in a lombok.config file, including the weird package names they use for the CF and the
+     * {@code @NotCalledMethods} annotation that they use even though we don't (and never have) supported
+     * such a thing.
+     *
+     * The new code added in this block ensures that the object construction checker handles clients
+     * of the copied code correctly.
+     */
+
+    public static void testOldCalledMethodsGood(@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder pb) {
+        pb.build();
+    }
+
+    public static void testOldCalledMethodsBad(@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y"}) CheckerFrameworkBuilderBuilder pb) {
+        // :: error: finalizer.invocation.invalid
+        pb.build(); // pb requires y, z
+    }
+
+    /**
+     * End new, non-copied code.
+     */
+
+    int x;
+    int y;
+    int z;
+    List<String> names;
+    @java.lang.SuppressWarnings("all")
+    private static int $default$x() {
+        return 5;
+    }
+    @org.checkerframework.common.aliasing.qual.Unique
+    @java.lang.SuppressWarnings("all")
+    CheckerFrameworkBuilder(final int x, final int y, final int z, final List<String> names) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.names = names;
+    }
+    @java.lang.SuppressWarnings("all")
+    public static class CheckerFrameworkBuilderBuilder {
+        @java.lang.SuppressWarnings("all")
+        private boolean x$set;
+        @java.lang.SuppressWarnings("all")
+        private int x$value;
+        @java.lang.SuppressWarnings("all")
+        private int y;
+        @java.lang.SuppressWarnings("all")
+        private int z;
+        @java.lang.SuppressWarnings("all")
+        private java.util.ArrayList<String> names;
+        @org.checkerframework.common.aliasing.qual.Unique
+        @java.lang.SuppressWarnings("all")
+        CheckerFrameworkBuilderBuilder() {
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(CheckerFrameworkBuilder.@org.checkerframework.checker.builder.qual.NotCalledMethods("x") CheckerFrameworkBuilderBuilder this, final int x) {
+            this.x$value = x;
+            x$set = true;
+            return this;
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(CheckerFrameworkBuilder.@org.checkerframework.checker.builder.qual.NotCalledMethods("y") CheckerFrameworkBuilderBuilder this, final int y) {
+            this.y = y;
+            return this;
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(CheckerFrameworkBuilder.@org.checkerframework.checker.builder.qual.NotCalledMethods("z") CheckerFrameworkBuilderBuilder this, final int z) {
+            this.z = z;
+            return this;
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder name(final String name) {
+            if (this.names == null) this.names = new java.util.ArrayList<String>();
+            this.names.add(name);
+            return this;
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder names(final java.util.Collection<? extends String> names) {
+            if (names == null) {
+                throw new java.lang.NullPointerException("names cannot be null");
+            }
+            if (this.names == null) this.names = new java.util.ArrayList<String>();
+            this.names.addAll(names);
+            return this;
+        }
+        @org.checkerframework.checker.builder.qual.ReturnsReceiver
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder clearNames() {
+            if (this.names != null) this.names.clear();
+            return this;
+        }
+        @org.checkerframework.dataflow.qual.SideEffectFree
+        @java.lang.SuppressWarnings("all")
+        public CheckerFrameworkBuilder build(CheckerFrameworkBuilder.@org.checkerframework.checker.builder.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder this) {
+            java.util.List<String> names;
+            switch (this.names == null ? 0 : this.names.size()) {
+                case 0:
+                    names = java.util.Collections.emptyList();
+                    break;
+                case 1:
+                    names = java.util.Collections.singletonList(this.names.get(0));
+                    break;
+                default:
+                    names = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(this.names));
+            }
+            int x$value = this.x$value;
+            if (!this.x$set) x$value = CheckerFrameworkBuilder.$default$x();
+            return new CheckerFrameworkBuilder(x$value, this.y, this.z, names);
+        }
+        @org.checkerframework.dataflow.qual.SideEffectFree
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        public java.lang.String toString() {
+            return "CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder(x$value=" + this.x$value + ", y=" + this.y + ", z=" + this.z + ", names=" + this.names + ")";
+        }
+    }
+    @org.checkerframework.dataflow.qual.SideEffectFree
+    @java.lang.SuppressWarnings("all")
+    public static CheckerFrameworkBuilder.@org.checkerframework.common.aliasing.qual.Unique CheckerFrameworkBuilderBuilder builder() {
+        return new CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder();
+    }
+}

--- a/object-construction-checker/tests/lombok/OldInherited.java
+++ b/object-construction-checker/tests/lombok/OldInherited.java
@@ -1,0 +1,45 @@
+// This is a test for the old @ReturnsReceiver annotation, which is inherited.
+// No one should ever write that annotation, but Lombok generates it as of version 1.18.10.
+
+import org.checkerframework.checker.builder.qual.ReturnsReceiver;
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+class OldInherited {
+    @ReturnsReceiver
+    OldInherited getThis() {
+        return this;
+    }
+
+    static class OldInheritedChild extends OldInherited {
+        @java.lang.Override
+        OldInherited getThis() {
+            return this;
+        }
+    }
+
+    void requiresGetThis(@CalledMethods("getThis") OldInherited this) { }
+
+    public static void testGoodParent() {
+        OldInherited o = new OldInherited();
+        o.getThis();
+        o.requiresGetThis();
+    }
+
+    public static void testGoodChild() {
+        OldInheritedChild o = new OldInheritedChild();
+        o.getThis();
+        o.requiresGetThis();
+    }
+
+    public static void testBadParent() {
+        OldInherited o = new OldInherited();
+        // :: error: finalizer.invocation.invalid
+        o.requiresGetThis();
+    }
+
+    public static void testBadChild() {
+        OldInheritedChild o = new OldInheritedChild();
+        // :: error: finalizer.invocation.invalid
+        o.requiresGetThis();
+    }
+}

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -16,6 +16,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface CalledMethods {
-  /** @return the names of the methods that have been called.*/
+  /** @return the names of the methods that have been called. */
   String[] value();
 }

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -16,6 +16,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface CalledMethods {
-  /** The names of the methods that have been called. */
+  /** @return the names of the methods that have been called.*/
   String[] value();
 }

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -9,15 +9,13 @@ import java.lang.annotation.Target;
 /**
  * For compatibility with Lombok, retain the old annotations it generates.
  *
- * You should use {@link org.checkerframework.checker.objectconstruction.qual.CalledMethods}
+ * <p>You should use {@link org.checkerframework.checker.objectconstruction.qual.CalledMethods}
  * instead. The Object Construction Checker treats this annotation as identical to that one.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface CalledMethods {
-    /**
-     * The names of the methods that have been called.
-     */
-    String[] value();
+  /** The names of the methods that have been called. */
+  String[] value();
 }

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -1,0 +1,23 @@
+package org.checkerframework.checker.builder.qual;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * For compatibility with Lombok, retain the old annotations it generates.
+ *
+ * You should use {@link org.checkerframework.checker.objectconstruction.qual.CalledMethods}
+ * instead. The Object Construction Checker treats this annotation as identical to that one.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface CalledMethods {
+    /**
+     * The names of the methods that have been called.
+     */
+    String[] value();
+}

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/NotCalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/NotCalledMethods.java
@@ -7,15 +7,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation speculatively used by Lombok's lombok.config checkerframework = true option.
- * It has not meaning to the Object Construction Checker, which treats it as
- * {@link org.checkerframework.checker.objectconstruction.qual.CalledMethodsTop}.
+ * An annotation speculatively used by Lombok's lombok.config checkerframework = true option. It has
+ * not meaning to the Object Construction Checker, which treats it as {@link
+ * org.checkerframework.checker.objectconstruction.qual.CalledMethodsTop}.
  *
- * A similar annotation might be supported in the future.
+ * <p>A similar annotation might be supported in the future.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface NotCalledMethods {
-    String[] value();
+  String[] value();
 }

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/NotCalledMethods.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/builder/qual/NotCalledMethods.java
@@ -1,0 +1,21 @@
+package org.checkerframework.checker.builder.qual;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation speculatively used by Lombok's lombok.config checkerframework = true option.
+ * It has not meaning to the Object Construction Checker, which treats it as
+ * {@link org.checkerframework.checker.objectconstruction.qual.CalledMethodsTop}.
+ *
+ * A similar annotation might be supported in the future.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface NotCalledMethods {
+    String[] value();
+}

--- a/returnsrcvr-qual/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
+++ b/returnsrcvr-qual/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
@@ -13,9 +13,10 @@ import java.lang.annotation.Target;
  * <p>This annotation can only be written on a method declaration. It is inherited by all overrides
  * of that method.
  *
- * This annotation has been replaced by {@link org.checkerframework.checker.returnsrcvr.qual.This}.
- * It is retained only for backwards-compatibility, including with Lombok's checkerframework = true lombok.config
- * flag. It should not be used in new code, because it is TRUSTED, NOT CHECKED.
+ * <p>This annotation has been replaced by {@link
+ * org.checkerframework.checker.returnsrcvr.qual.This}. It is retained only for
+ * backwards-compatibility, including with Lombok's checkerframework = true lombok.config flag. It
+ * should not be used in new code, because it is TRUSTED, NOT CHECKED.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/returnsrcvr-qual/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
+++ b/returnsrcvr-qual/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
@@ -1,0 +1,23 @@
+package org.checkerframework.checker.builder.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This declaration annotation indicates that the method on which it is written returns exactly the
+ * receiver object.
+ *
+ * <p>This annotation can only be written on a method declaration. It is inherited by all overrides
+ * of that method.
+ *
+ * This annotation has been replaced by {@link org.checkerframework.checker.returnsrcvr.qual.This}.
+ * It is retained only for backwards-compatibility, including with Lombok's checkerframework = true lombok.config
+ * flag. It should not be used in new code, because it is TRUSTED, NOT CHECKED.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+public @interface ReturnsReceiver {}


### PR DESCRIPTION
I copied the delombok'd test code directly from Lombok's source, so this should match exactly what they do.

The downside is that we have to go back to releasing annotations in the `org.checkerframework.checker.builder.qual` package, but I don't think that's a deal breaker. I considered marking them as deprecated, but that caused extra warnings when processing delombok'd code so I decided against it.

The annotations this adds support for are:
* `@CalledMethods` in the `builder.qual` namespace, which behaves identically to `@CalledMethods`
* `@NotCalledMethods`, which they (speculatively) generate, does nothing
* `@ReturnsReceiver` is trusted if it's found but no `@This` annotation is. This is the only one I'm a little worried about, but I think it's probably fine. The Javadoc on it makes it clear that users should use `@This` instead, and that's also what our README etc say