### PR TITLE
Broaden type of argument to CalledMethodsPredicateEvaluator

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/CalledMethodsPredicateEvaluator.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/CalledMethodsPredicateEvaluator.java
@@ -1,6 +1,6 @@
 package org.checkerframework.checker.objectconstruction;
 
-import java.util.Set;
+import java.util.Collection;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -8,10 +8,10 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 /** This class parses and evaluates a single @CalledMethodsPredicate argument. */
 public class CalledMethodsPredicateEvaluator {
 
-  // A set containing all the names of methods that ought to evaluate to true.
-  private final Set<String> cmMethods;
+  // All the names of methods that ought to evaluate to true.
+  private final Collection<String> cmMethods;
 
-  public CalledMethodsPredicateEvaluator(final Set<String> cmMethods) {
+  public CalledMethodsPredicateEvaluator(final Collection<String> cmMethods) {
     this.cmMethods = cmMethods;
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -435,10 +435,10 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
         return false;
       }
 
-      Set<String> subVal =
+      List<String> subVal =
           AnnotationUtils.areSame(subAnno, TOP)
-              ? Collections.emptySet()
-              : new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(subAnno));
+              ? Collections.emptyList()
+              : getValueOfAnnotationWithStringArgument(subAnno);
 
       if (AnnotationUtils.areSameByClass(superAnno, CalledMethodsPredicate.class)) {
         // superAnno is a CMP annotation, so we need to evaluate the predicate

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -26,7 +26,7 @@ public class ObjectConstructionVisitor
       String predicate = AnnotationUtils.getElementValue(anno, "value", String.class, false);
 
       try {
-        new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate);
+        new CalledMethodsPredicateEvaluator(Collections.emptyList()).evaluate(predicate);
       } catch (SpelParseException e) {
         checker.report(Result.failure("predicate.invalid", e.getMessage()), node);
         return null;


### PR DESCRIPTION
This enables elimination of a copy operation in `ObjectConstructionAnnotatedTypeFactory.java`.