### PR TITLE
Add configuration to only run dependabot once a week

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
so I'm not spammed with updates to the AWS SDK every day