### PR TITLE
Add @EnsuresCalledMethodsVarArgs annotation

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -20,7 +20,13 @@ import org.checkerframework.framework.source.SuppressWarningsPrefix;
   ObjectConstructionChecker.COUNT_FRAMEWORK_BUILD_CALLS,
   ObjectConstructionChecker.DISABLED_FRAMEWORK_SUPPORTS,
 })
-@StubFiles({"Socket.astub", "NotOwning.astub", "Stream.astub", "AlwaysCallEmpty.astub", "IOUtils.astub"})
+@StubFiles({
+  "Socket.astub",
+  "NotOwning.astub",
+  "Stream.astub",
+  "AlwaysCallEmpty.astub",
+  "IOUtils.astub"
+})
 public class ObjectConstructionChecker extends BaseTypeChecker {
 
   public static final String USE_VALUE_CHECKER = "useValueChecker";
@@ -63,6 +69,9 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
     messages.setProperty(
         "finalizer.invocation.invalid",
         "This finalizer cannot be invoked, because the following methods have not been called: %s\n");
+    messages.setProperty(
+        "ensuresvarargs.annotation.invalid",
+        "@EnsuresCalledMethodsVarArgs cannot be written on a non-varargs method");
     messages.setProperty(
         "predicate.invalid",
         "An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S --> method name | (S) | S && S | S || S. The message from the evaluator was: %s \\n");

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -73,6 +73,9 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
         "ensuresvarargs.annotation.invalid",
         "@EnsuresCalledMethodsVarArgs cannot be written on a non-varargs method");
     messages.setProperty(
+        "ensuresvarargs.unverified",
+        "@EnsuresCalledMethodsVarArgs cannot be verified yet.  Please suppress this warning.");
+    messages.setProperty(
         "predicate.invalid",
         "An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S --> method name | (S) | S && S | S || S. The message from the evaluator was: %s \\n");
     messages.setProperty(

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -74,7 +74,7 @@ public class ObjectConstructionChecker extends BaseTypeChecker {
         "@EnsuresCalledMethodsVarArgs cannot be written on a non-varargs method");
     messages.setProperty(
         "ensuresvarargs.unverified",
-        "@EnsuresCalledMethodsVarArgs cannot be verified yet.  Please suppress this warning.");
+        "@EnsuresCalledMethodsVarArgs cannot be verified yet.  Please check that the implementation of the method actually does call the given methods on the varargs parameters by hand, and then suppress the warning.");
     messages.setProperty(
         "predicate.invalid",
         "An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S --> method name | (S) | S && S | S || S. The message from the evaluator was: %s \\n");

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -154,7 +154,6 @@ public class ObjectConstructionTransfer extends CFTransfer {
             .toArray(new String[0]);
     List<? extends VariableElement> parameters = elt.getParameters();
     int varArgsPos = parameters.size() - 1;
-    // are we passing an array, or multiple arguments?
     Node varArgActual = node.getArguments().get(varArgsPos);
     // In the CFG, explicit passing of multiple arguments in the varargs position is represented via
     // an ArrayCreationNode.  This is the only case we handle for now.

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -5,6 +5,7 @@ import static javax.lang.model.element.ElementKind.LOCAL_VARIABLE;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
@@ -22,6 +23,7 @@ import org.checkerframework.checker.objectconstruction.framework.FrameworkSuppor
 import org.checkerframework.checker.objectconstruction.qual.AlwaysCall;
 import org.checkerframework.checker.objectconstruction.qual.CalledMethods;
 import org.checkerframework.checker.objectconstruction.qual.CalledMethodsPredicate;
+import org.checkerframework.checker.objectconstruction.qual.EnsuresCalledMethodsVarArgs;
 import org.checkerframework.checker.objectconstruction.qual.NotOwning;
 import org.checkerframework.checker.objectconstruction.qual.Owning;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -58,6 +60,21 @@ public class ObjectConstructionVisitor
       }
     }
     return super.visitAnnotation(node, p);
+  }
+
+  @Override
+  public Void visitMethod(MethodTree node, Void p) {
+    ExecutableElement elt = TreeUtils.elementFromDeclaration(node);
+    Set<AnnotationMirror> declAnnotations = atypeFactory.getDeclAnnotations(elt);
+    AnnotationMirror annot = atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethodsVarArgs.class);
+    if (annot != null) {
+      if (!elt.isVarArgs()) {
+        checker.report(
+            node, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.annotation.invalid"));
+        return null;
+      }
+    }
+    return super.visitMethod(node, p);
   }
 
   @Override

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -69,7 +69,6 @@ public class ObjectConstructionVisitor
   @Override
   public Void visitMethod(MethodTree node, Void p) {
     ExecutableElement elt = TreeUtils.elementFromDeclaration(node);
-    Set<AnnotationMirror> declAnnotations = atypeFactory.getDeclAnnotations(elt);
     AnnotationMirror annot = atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethodsVarArgs.class);
     if (annot != null) {
       if (!elt.isVarArgs()) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -58,6 +58,10 @@ public class ObjectConstructionVisitor
             node, new DiagMessage(Diagnostic.Kind.ERROR, "predicate.invalid", e.getMessage()));
         return null;
       }
+    } else if (AnnotationUtils.areSameByClass(anno, EnsuresCalledMethodsVarArgs.class)) {
+      // we can't verify these yet.  emit an error (which will have to be suppressed) for now
+      checker.report(node, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.unverified"));
+      return null;
     }
     return super.visitAnnotation(node, p);
   }

--- a/object-construction-checker/tests/basic/PostconditionVarArgs.java
+++ b/object-construction-checker/tests/basic/PostconditionVarArgs.java
@@ -17,6 +17,7 @@ class PostconditionVarArgs {
   }
 
   @EnsuresCalledMethodsVarArgs("b")
+  // :: error: ensuresvarargs.annotation.invalid
   static void callBBadAnnot(PostconditionVarArgs x) {
     x.b();
   }
@@ -62,7 +63,8 @@ class PostconditionVarArgs {
   static void invokeCallBAndCArray() {
     PostconditionVarArgs y = new PostconditionVarArgs();
     PostconditionVarArgs z = new PostconditionVarArgs();
-    callBAndC(new PostconditionVarArgs[] {y, z});
+    PostconditionVarArgs[] argsArray = {y, z};
+    callBAndC(argsArray);
     // because we don't handle arrays
     // :: error: finalizer.invocation.invalid
     y.build();

--- a/object-construction-checker/tests/basic/PostconditionVarArgs.java
+++ b/object-construction-checker/tests/basic/PostconditionVarArgs.java
@@ -8,7 +8,7 @@ class PostconditionVarArgs {
 
   void c() {}
 
-  // TODO suppress warnings
+  // :: error: ensuresvarargs.unverified
   @EnsuresCalledMethodsVarArgs("b")
   static void callB(PostconditionVarArgs... x) {
     for (PostconditionVarArgs p : x) {
@@ -22,7 +22,7 @@ class PostconditionVarArgs {
     x.b();
   }
 
-  // TODO suppress warnings
+  // :: error: ensuresvarargs.unverified
   @EnsuresCalledMethodsVarArgs({"b", "c"})
   static void callBAndC(PostconditionVarArgs... x) {
     for (PostconditionVarArgs p : x) {

--- a/object-construction-checker/tests/basic/PostconditionVarArgs.java
+++ b/object-construction-checker/tests/basic/PostconditionVarArgs.java
@@ -1,0 +1,77 @@
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+/** Test for postcondition support via @EnsureCalledMethods */
+class PostconditionVarArgs {
+  void build(@CalledMethods({"b", "c"}) PostconditionVarArgs this) {}
+
+  void b() {}
+
+  void c() {}
+
+  // TODO suppress warnings
+  @EnsuresCalledMethodsVarArgs("b")
+  static void callB(PostconditionVarArgs... x) {
+    for (PostconditionVarArgs p : x) {
+      p.b();
+    }
+  }
+
+  @EnsuresCalledMethodsVarArgs("b")
+  static void callBBadAnnot(PostconditionVarArgs x) {
+    x.b();
+  }
+
+  // TODO suppress warnings
+  @EnsuresCalledMethodsVarArgs({"b", "c"})
+  static void callBAndC(PostconditionVarArgs... x) {
+    for (PostconditionVarArgs p : x) {
+      p.b();
+      p.c();
+    }
+  }
+
+
+  static void invokeCallB() {
+    PostconditionVarArgs y = new PostconditionVarArgs();
+    PostconditionVarArgs z = new PostconditionVarArgs();
+    callB(y, z);
+    y.c();
+    z.c();
+    y.build();
+    z.build();
+  }
+
+  static void invokeCallBLast() {
+    PostconditionVarArgs y = new PostconditionVarArgs();
+    PostconditionVarArgs z = new PostconditionVarArgs();
+    y.c();
+    z.c();
+    callB(y, z);
+    y.build();
+    z.build();
+  }
+
+  static void invokeCallBAndC() {
+    PostconditionVarArgs y = new PostconditionVarArgs();
+    PostconditionVarArgs z = new PostconditionVarArgs();
+    callBAndC(y, z);
+    y.build();
+    z.build();
+  }
+
+  static void invokeCallBAndCArray() {
+    PostconditionVarArgs y = new PostconditionVarArgs();
+    PostconditionVarArgs z = new PostconditionVarArgs();
+    callBAndC(new PostconditionVarArgs[] {y, z});
+    // because we don't handle arrays
+    // :: error: finalizer.invocation.invalid
+    y.build();
+  }
+
+  static void invokeCallBWrong() {
+    PostconditionVarArgs y = new PostconditionVarArgs();
+    callB(y);
+    // :: error: finalizer.invocation.invalid
+    y.build();
+  }
+}

--- a/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/EnsuresCalledMethodsVarArgs.java
+++ b/object-construction-qual/src/main/java/org/checkerframework/checker/objectconstruction/qual/EnsuresCalledMethodsVarArgs.java
@@ -1,0 +1,25 @@
+package org.checkerframework.checker.objectconstruction.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the method, if it terminates successfully, always invokes the given methods on all
+ * of the arguments passed in the varargs position.
+ *
+ * <p>Consider the following method:
+ *
+ * <pre>
+ * &#64;EnsuresCalledMethodsVarArgs("m")
+ * public void callMOnAll(S s, T t...) { ... }
+ * </pre>
+ *
+ * <p>This method guarantees that {@code m()} is always called on every {@code T} object passed in
+ * the {@code t} varargs argument before the method returns.
+ */
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface EnsuresCalledMethodsVarArgs {
+
+  /** @return the methods guaranteed to be invoked on the varargs parameters */
+  String[] value();
+}


### PR DESCRIPTION
Add an `@EnsuresCalledsMethodVarArgs` annotation for methods, indicating that certain methods are called on _all_ parameters passed in the varargs position to the annotated method.  For now, this annotation is unverified and we always issue a warning when it is used.  Add support for `@EnsuresCalledMethodsVarArgs` to the transfer function of the object construction checker.