### PR TITLE
Fix a crash and add a couple optimizations

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -91,7 +91,6 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.trees.DetachedVarSymbol;
 
 /**
  * The annotated type factory for the object construction checker. Primarily responsible for the
@@ -413,8 +412,6 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
           }
 
           if (lhs instanceof LocalVariableNode
-              // don't track synthetic variables
-              && !(((LocalVariableNode) lhs).getElement() instanceof DetachedVarSymbol)
               && !isTryWithResourcesVariable((LocalVariableNode) lhs)) {
 
             // Reassignment to the lhs

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -821,7 +821,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
     public BlockWithLocals(Block b, Set<LocalVarWithAssignTree> ls) {
       this.block = (BlockImpl) b;
-      this.localSetInfo = Collections.unmodifiableSet(ls);
+      this.localSetInfo = ls;
     }
 
     @Override

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -774,7 +774,9 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
     AnnotationMirror cmAnno;
 
-    CFValue lhsCFValue = store.getValue(assign.localVar);
+    // sometimes the store is null!  this looks like a bug in checker dataflow.
+    // TODO track down and report the root-cause bug
+    CFValue lhsCFValue = store != null ? store.getValue(assign.localVar) : null;
     if (lhsCFValue != null) { // When store contains the lhs
       cmAnno =
           lhsCFValue.getAnnotations().stream()

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -89,7 +90,6 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -732,11 +732,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private void propagate(
       BlockWithLocals state, Set<BlockWithLocals> visited, Deque<BlockWithLocals> worklist) {
 
-    if (visited.stream()
-        .noneMatch(
-            pair ->
-                pair.block.equals(state.block) && pair.localSetInfo.equals(state.localSetInfo))) {
-      visited.add(state);
+    if (visited.add(state)) {
       worklist.add(state);
     }
   }
@@ -819,13 +815,26 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
     return !getMustCallValue(t).isEmpty();
   }
 
-  private class BlockWithLocals {
-    public BlockImpl block;
-    public Set<LocalVarWithAssignTree> localSetInfo;
+  private static class BlockWithLocals {
+    public final BlockImpl block;
+    public final Set<LocalVarWithAssignTree> localSetInfo;
 
     public BlockWithLocals(Block b, Set<LocalVarWithAssignTree> ls) {
       this.block = (BlockImpl) b;
-      this.localSetInfo = ls;
+      this.localSetInfo = Collections.unmodifiableSet(ls);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      BlockWithLocals that = (BlockWithLocals) o;
+      return block.equals(that.block) && localSetInfo.equals(that.localSetInfo);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(block, localSetInfo);
     }
   }
 
@@ -835,8 +844,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
    * formal parameter
    */
   private static class LocalVarWithAssignTree {
-    public LocalVariable localVar;
-    public Tree assignTree;
+    public final LocalVariable localVar;
+    public final Tree assignTree;
 
     public LocalVarWithAssignTree(LocalVariable localVarNode, Tree assignTree) {
       this.localVar = localVarNode;
@@ -854,20 +863,15 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      LocalVarWithAssignTree localVarWithAssignTree = (LocalVarWithAssignTree) o;
-      return localVar.equals(localVarWithAssignTree.localVar)
-          && assignTree.equals(localVarWithAssignTree.assignTree);
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      LocalVarWithAssignTree that = (LocalVarWithAssignTree) o;
+      return localVar.equals(that.localVar) && assignTree.equals(that.assignTree);
     }
 
     @Override
     public int hashCode() {
-      return Pair.of(localVar, assignTree).hashCode();
+      return Objects.hash(localVar, assignTree);
     }
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -768,6 +768,10 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
   private void checkMustCall(
       LocalVarWithAssignTree assign, CFStore store, String outOfScopeReason) {
     List<String> mustCallValue = getMustCallValue(assign.assignTree);
+    // optimization: if there are no must-call methods, we do not need to perform the check
+    if (mustCallValue.isEmpty()) {
+      return;
+    }
     AnnotationMirror dummyCMAnno = createCalledMethods(mustCallValue.toArray(new String[0]));
 
     boolean report = true;

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -91,6 +91,7 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.trees.DetachedVarSymbol;
 
 /**
  * The annotated type factory for the object construction checker. Primarily responsible for the
@@ -412,6 +413,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends BaseAnnotatedTypeFac
           }
 
           if (lhs instanceof LocalVariableNode
+              // don't track synthetic variables
+              && !(((LocalVariableNode) lhs).getElement() instanceof DetachedVarSymbol)
               && !isTryWithResourcesVariable((LocalVariableNode) lhs)) {
 
             // Reassignment to the lhs

--- a/object-construction-checker/tests/mustcall/MustCallNullStore.java
+++ b/object-construction-checker/tests/mustcall/MustCallNullStore.java
@@ -1,0 +1,21 @@
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+// input exposing a bug where store after the return is null
+class MustCallNullStore {
+
+  int inflateDirect(ByteBuffer src, ByteBuffer dst) throws java.io.IOException {
+
+    ByteBuffer presliced = dst;
+    if (dst.position() > 0) {
+      dst = dst.slice();
+    }
+
+    int n = 0;
+    try {
+      presliced.position(presliced.position() + n);
+    } finally {
+    }
+    return n;
+  }
+  }

--- a/object-construction-checker/tests/mustcall/MustCallNullStore.java
+++ b/object-construction-checker/tests/mustcall/MustCallNullStore.java
@@ -18,4 +18,4 @@ class MustCallNullStore {
     }
     return n;
   }
-  }
+}


### PR DESCRIPTION
The crash showed up when checking Hadoop.  I think it's potentially an issue with Checker data flow.  For now, add a null check to work around it.  Also add a couple of optimizations.  The optimization to `propagate()` speeds up the worklist algorithm quite a bit in some cases.