### PR TITLE
Fix serious mistake in handling of generics

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -30,7 +30,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayTyp
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.MostlyNoElementQualifierHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.visitor.SimpleAnnotatedTypeScanner;
 import org.checkerframework.framework.util.QualifierKind;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.BugInCF;

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -5,6 +5,7 @@ import static org.checkerframework.common.value.ValueCheckerUtils.getValueOfAnno
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -98,6 +99,20 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     } else {
       throw new BugInCF("unexpected type of method tree: " + tree.getKind());
     }
+    changeParameterTypesToTop(declaration, type);
+    super.methodFromUsePreSubstitution(tree, type);
+  }
+
+  @Override
+  protected void constructorFromUsePreSubstitution(
+      NewClassTree tree, AnnotatedExecutableType type) {
+    ExecutableElement declaration = TreeUtils.elementFromUse(tree);
+    changeParameterTypesToTop(declaration, type);
+    super.constructorFromUsePreSubstitution(tree, type);
+  }
+
+  private void changeParameterTypesToTop(
+      ExecutableElement declaration, AnnotatedExecutableType type) {
     for (int i = 0; i < type.getParameterTypes().size(); i++) {
       Element paramDecl = declaration.getParameters().get(i);
       if (getDeclAnnotation(paramDecl, Owning.class) == null) {
@@ -116,7 +131,6 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
       }
     }
-    super.methodFromUsePreSubstitution(tree, type);
   }
 
   @Override

--- a/must-call-checker/tests/mustcall/BinaryInputArchive.java
+++ b/must-call-checker/tests/mustcall/BinaryInputArchive.java
@@ -1,0 +1,18 @@
+// Test case based on a false positive reported by Narges that was
+// caused by not respecting ownership transfer rules for constructor params.
+
+import java.io.*;
+class BinaryInputArchive{
+
+    private DataInput in;
+
+    public BinaryInputArchive(DataInput in) {
+        this.in = in;
+    }
+
+    public static BinaryInputArchive getArchive(InputStream strm) {
+        return new BinaryInputArchive(
+                new DataInputStream(
+                        strm));
+    }
+}

--- a/must-call-checker/tests/mustcall/FieldInitializationWithGeneric.java
+++ b/must-call-checker/tests/mustcall/FieldInitializationWithGeneric.java
@@ -1,0 +1,8 @@
+// based on a false positive I found in Zookeeper
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+class FieldInitializationWithGeneric {
+    private Set<String> activeObservers = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+}

--- a/must-call-checker/tests/mustcall/SimpleStreamExample.java
+++ b/must-call-checker/tests/mustcall/SimpleStreamExample.java
@@ -1,0 +1,9 @@
+// Based on a false positive in Zookeeper
+
+import java.util.*;
+
+class SimpleStreamExample {
+    static void test(List<SimpleStreamExample> s) {
+        s.stream().filter(str -> str == null);
+    }
+}

--- a/must-call-checker/tests/mustcall/StringSort.java
+++ b/must-call-checker/tests/mustcall/StringSort.java
@@ -1,0 +1,10 @@
+// Another false positive I found in Zookeeper.
+
+import java.util.*;
+
+class StringSort {
+    public static void sort() {
+        List<String> myList = new ArrayList<String>();
+        Collections.sort(myList);
+    }
+}

--- a/must-call-checker/tests/mustcall/TypeArgs.java
+++ b/must-call-checker/tests/mustcall/TypeArgs.java
@@ -8,7 +8,7 @@ public class TypeArgs {
     static class B<S> extends A<S> {}
 
     public <T> void f1(Generic<T> real, Generic<? super T> other, boolean flag) {
-        // :: error: (argument.type.incompatible)
+        // :: error: (type.argument.type.incompatible)
         f2(flag ? real : other);
     }
 


### PR DESCRIPTION
A PR comment on #207 suggested using a `SimpleAnnotatedTypeScanner` rather than manually replacing only the top-level annotation for non-owning method parameters. That was a mistake.

The original reason that any types were replaced was to avoid false positive warnings when ownership wasn't being transferred. Using a type scanner causes the replacement to happen throughout the whole type - that seems good, but actually is a serious problem because generics are invariant: `@MustCallUnknown List<@MustCallUnknown String>` is NOT a supertype of `@MustCall({}) List<@MustCall({}) String>`, which generates a different spurious false positive.

This PR fixes the implementation and adds some test cases based on FPs in Zookeeper that this problem caused to prevent its recurrence.