### PR TITLE
Treat non-owning method parameters as @MustCall({}) while typechecking the body of the method

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -1,7 +1,5 @@
 package org.checkerframework.checker.mustcall;
 
-import static javax.lang.model.element.ElementKind.CONSTRUCTOR;
-import static javax.lang.model.element.ElementKind.METHOD;
 import static javax.lang.model.element.ElementKind.PARAMETER;
 import static org.checkerframework.common.value.ValueCheckerUtils.getValueOfAnnotationWithStringArgument;
 
@@ -20,14 +18,12 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.Elements;
 import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.mustcall.qual.MustCallUnknown;
 import org.checkerframework.checker.mustcall.qual.PolyMustCall;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.qual.Owning;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -266,37 +262,10 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror type) {
       Element elt = TreeUtils.elementFromTree(node);
-      if (elt.getKind() != PARAMETER) {
-        return super.visitIdentifier(node, type);
-      }
-      /// This code derived from ElementUtils#enclosingClass
-      Element enclosing = elt;
-      while (enclosing != null && !(isMethodElement(enclosing))) {
-        @Nullable Element encl = enclosing.getEnclosingElement();
-        enclosing = encl;
-      }
-      ///
-      if (enclosing != null) {
-        ExecutableElement enclosingMethod = (ExecutableElement) enclosing;
-        VariableElement decl = null;
-        for (VariableElement param : enclosingMethod.getParameters()) {
-          // Scoping rules should mean these are the same - there can only one
-          // parameter in a given method with a particular simple name.
-          if (param.getSimpleName().contentEquals(elt.getSimpleName())) {
-            decl = param;
-            break;
-          }
-        }
-        if (decl != null && getDeclAnnotation(decl, Owning.class) == null) {
-          type.replaceAnnotation(BOTTOM);
-        }
+      if (elt.getKind() == PARAMETER && getDeclAnnotation(elt, Owning.class) == null) {
+        type.replaceAnnotation(BOTTOM);
       }
       return super.visitIdentifier(node, type);
-    }
-
-    /** Equivalent to ElementUtils#isClassElement for methods. */
-    private boolean isMethodElement(Element elt) {
-      return elt.getKind() == METHOD || elt.getKind() == CONSTRUCTOR;
     }
   }
 }

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.mustcall;
 
 import static javax.lang.model.element.ElementKind.CONSTRUCTOR;
 import static javax.lang.model.element.ElementKind.METHOD;
+import static javax.lang.model.element.ElementKind.PARAMETER;
 import static org.checkerframework.common.value.ValueCheckerUtils.getValueOfAnnotationWithStringArgument;
 
 import com.sun.source.tree.ExpressionTree;
@@ -265,6 +266,9 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror type) {
       Element elt = TreeUtils.elementFromTree(node);
+      if (elt.getKind() != PARAMETER) {
+        return super.visitIdentifier(node, type);
+      }
       /// This code derived from ElementUtils#enclosingClass
       Element enclosing = elt;
       while (enclosing != null && !(isMethodElement(enclosing))) {
@@ -276,8 +280,8 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         ExecutableElement enclosingMethod = (ExecutableElement) enclosing;
         VariableElement decl = null;
         for (VariableElement param : enclosingMethod.getParameters()) {
-          // scoping rules should mean these are the same? I hope?
-          // TODO: find a better way to associate an identifier with a method parameter...
+          // Scoping rules should mean these are the same - there can only one
+          // parameter in a given method with a particular simple name.
           if (param.getSimpleName().contentEquals(elt.getSimpleName())) {
             decl = param;
             break;

--- a/must-call-checker/tests/mustcall/LogTheSocket.java
+++ b/must-call-checker/tests/mustcall/LogTheSocket.java
@@ -18,7 +18,7 @@ import java.net.ServerSocket;
 import java.nio.channels.SocketChannel;
 import java.io.IOException;
 
-import org.checkerframework.checker.objectconstruction.qual.NotOwning;
+import org.checkerframework.checker.objectconstruction.qual.*;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 
 class LogTheSocket {
@@ -27,7 +27,7 @@ class LogTheSocket {
 
     @MustCall("") Object s2;
 
-    void testAssign(ServerSocket s1) {
+    void testAssign(@Owning ServerSocket s1) {
         s = s1;
         // :: error: assignment.type.incompatible
         s2 = s1;

--- a/must-call-checker/tests/mustcall/NonOwningPolyInteraction.java
+++ b/must-call-checker/tests/mustcall/NonOwningPolyInteraction.java
@@ -1,0 +1,45 @@
+// A test that non-owning method parameters are really treated as @MustCall({})
+// wrt polymorphic types. Based on some false positives in Zookeeper and an example
+// written by Manu.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+import java.io.*;
+
+class NonOwningPolyInteraction {
+    void foo(@NotOwning InputStream instream) {
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+
+    void bar(@Owning InputStream instream) {
+        // :: error: assignment.type.incompatible
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+
+    // default anno for params in @NotOwning
+    void baz(InputStream instream) {
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+
+    NonOwningPolyInteraction(@NotOwning InputStream instream) {
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+
+    // extra param(s) here and on the next constructor because Java requires constructors to have different signatures.
+    NonOwningPolyInteraction(@Owning InputStream instream, int x) {
+        // :: error: assignment.type.incompatible
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+
+    // default anno for params in @NotOwning
+    NonOwningPolyInteraction(InputStream instream, int x, int y) {
+        @MustCall({}) BufferedInputStream bis = new BufferedInputStream(instream);
+        @MustCall({"close"}) BufferedInputStream bis2 = new BufferedInputStream(instream);
+    }
+}

--- a/must-call-checker/tests/mustcall/OwningParams.java
+++ b/must-call-checker/tests/mustcall/OwningParams.java
@@ -8,7 +8,7 @@ class OwningParams {
 
     void o2(@Owning OwningParams this) { }
 
-    void test(@MustCall({"a"}) OwningParams o, OwningParams p) {
+    void test(@Owning @MustCall({"a"}) OwningParams o, @Owning OwningParams p) {
         // :: error: argument.type.incompatible
         o1(o);
         // TODO: this error doesn't show up! See MustCallVisitor#skipReceiverSubtypeCheck

--- a/must-call-checker/tests/mustcall/PolyTests.java
+++ b/must-call-checker/tests/mustcall/PolyTests.java
@@ -1,6 +1,7 @@
 // Unit tests for the poly annotation.
 
 import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
 
 @MustCall("close")
 class PolyTests {
@@ -8,13 +9,13 @@ class PolyTests {
         return obj;
     }
 
-    static void test1(@MustCall("close") Object o) {
+    static void test1(@Owning @MustCall("close") Object o) {
         @MustCall("close") Object o1 = id(o);
         // :: error: assignment.type.incompatible
         @MustCall({}) Object o2 = id(o);
     }
 
-    static void test2(@MustCall({}) Object o) {
+    static void test2(@Owning @MustCall({}) Object o) {
         @MustCall("close") Object o1 = id(o);
         @MustCall({}) Object o2 = id(o);
     }
@@ -25,18 +26,18 @@ class PolyTests {
 
     }
 
-    static void test3(@MustCall({"close"}) Object o) {
+    static void test3(@Owning @MustCall({"close"}) Object o) {
         @MustCall("close") Object o1 = new PolyTests(o);
         // :: error: assignment.type.incompatible
         @MustCall({}) Object o2 = new PolyTests(o);
     }
 
-    static void test4(@MustCall({}) Object o) {
+    static void test4(@Owning @MustCall({}) Object o) {
         @MustCall("close") Object o1 = new PolyTests(o);
         @MustCall({}) Object o2 = new PolyTests(o);
     }
 
-    static void testArbitary(PolyTests p) {
+    static void testArbitary(@Owning PolyTests p) {
         @MustCall("close") Object o1 = p;
         // :: error: assignment.type.incompatible
         @MustCall({}) Object o2 = p;

--- a/must-call-checker/tests/mustcall/Subtype0.java
+++ b/must-call-checker/tests/mustcall/Subtype0.java
@@ -1,6 +1,7 @@
 // A test that the @InheritedMustCall declaration annotation works correctly.
 
 import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
 
 @InheritableMustCall("a")
 public class Subtype0 {
@@ -10,7 +11,7 @@ public class Subtype0 {
     }
     public class Subtype2 extends Subtype1 { }
 
-    static void test(Subtype0 s0, Subtype1 s1, Subtype2 s2, Subtype3 s3, Subtype4 s4) {
+    static void test(@Owning Subtype0 s0, @Owning Subtype1 s1, @Owning Subtype2 s2, @Owning Subtype3 s3, @Owning Subtype4 s4) {
         // :: error: assignment.type.incompatible
         @MustCall({}) Object obj1 = s0;
         @MustCall({"a"}) Object obj2 = s0;

--- a/must-call-checker/tests/mustcall/Subtyping.java
+++ b/must-call-checker/tests/mustcall/Subtyping.java
@@ -1,12 +1,13 @@
 // simple subtyping test for the MustCall annotation
 
 import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
 
 class Subtyping {
 
     Object unannotatedObj;
 
-    void test_act(@MustCallUnknown Object o) {
+    void test_act(@Owning @MustCallUnknown Object o) {
         @MustCallUnknown Object act = o;
         // :: error: assignment.type.incompatible
         @MustCall("close") Object file = o;
@@ -18,7 +19,7 @@ class Subtyping {
         unannotatedObj = o;
     }
 
-    void test_close(@MustCall("close") Object o) {
+    void test_close(@Owning @MustCall("close") Object o) {
         @MustCallUnknown Object act = o;
         @MustCall("close") Object file = o;
         @MustCall({"close", "read"}) Object f2 = o;
@@ -28,7 +29,7 @@ class Subtyping {
         unannotatedObj = o;
     }
 
-    void test_close_read(@MustCall({"close", "read"}) Object o) {
+    void test_close_read(@Owning @MustCall({"close", "read"}) Object o) {
         @MustCallUnknown Object act = o;
         // :: error: assignment.type.incompatible
         @MustCall("close") Object file = o;
@@ -39,7 +40,7 @@ class Subtyping {
         unannotatedObj = o;
     }
 
-    void test_blank(@MustCall({}) Object o) {
+    void test_blank(@Owning @MustCall({}) Object o) {
         @MustCallUnknown Object act = o;
         @MustCall("close") Object file = o;
         @MustCall({"close", "read"}) Object f2 = o;
@@ -47,7 +48,7 @@ class Subtyping {
         unannotatedObj = o;
     }
 
-    void test_unannotated(Object o) {
+    void test_unannotated(@Owning Object o) {
         @MustCallUnknown Object act = o;
         @MustCall("close") Object file = o;
         @MustCall({"close", "read"}) Object f2 = o;


### PR DESCRIPTION
~~The implementation is kind of hacky and relies on there being no other identifiers in a method body with the same name as its parameters. I *think* the scoping rules make that true, but I'm not sure.~~

I tried a couple of ~~less hacky~~ _other_ ways to implement this, but they all failed. Here are the ones that were most promising:
* override `TypeAnnotator#visitExecutable` and `GenericAnnotatedTypeFactory#addComputedTypeAnnotations(Element, ...)`: also changes the types when the method is called, which causes lots of false positives.
* override `visitVariable` in a `TreeAnnotator`, and change the type of the variable (both in the caches and the parameter) if the variable being declared is a non-owning method parameter. Doesn't seem to do anything except cause polymorphic types to be resolved incorrectly.
* override `visitMethod` in a `TreeAnnotator`, since we really only want this change to take effect while we typecheck the method body. Doesn't do anything.

If a reviewer has a better way to do this, I'm very open to trying it!

Test changes are all because the relevant parameters were implicitly `@Owning` before, because the code is artificial and intended only to test the Must Call Checker.