### PR TITLE
Fix multiple-constructor false positives

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -220,6 +220,7 @@ class MustCallInvokedChecker {
       MethodInvocationTree methodInvokeTree = (MethodInvocationTree) callTree;
       return typeFactory.returnsThis(methodInvokeTree)
           || TreeUtils.isSuperConstructorCall(methodInvokeTree)
+          || TreeUtils.isThisConstructorCall(methodInvokeTree)
           || typeFactory.getDeclAnnotation(
                   TreeUtils.elementFromUse(methodInvokeTree), NotOwning.class)
               != null;

--- a/object-construction-checker/tests/mustcall/TwoConstructorsCloseable.java
+++ b/object-construction-checker/tests/mustcall/TwoConstructorsCloseable.java
@@ -1,0 +1,23 @@
+// A test case for false positives that I encountered in Zookeeper.
+
+import java.io.Closeable;
+
+public class TwoConstructorsCloseable implements Closeable {
+    public TwoConstructorsCloseable(Object obj) {
+
+    }
+
+    public TwoConstructorsCloseable() {
+        this(null);
+    }
+
+    public void close() {
+
+    }
+
+    class Derivative extends TwoConstructorsCloseable {
+        Derivative() {
+            super(null);
+        }
+    }
+}


### PR DESCRIPTION
Without this change an error like the following is issued at line 11 of the test case:

```
[ERROR] /scratch/kelloggm/zookeeper/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java:[170,12] error: [required.method.not.called] @MustCall method(s) close,  for variable/expression not invoked.  The type of object is: void.  Reason for going out of scope: never assigned to a variable
```

This is pretty clearly a false positive. I found two of them in Zookeeper. That's not a lot, but the fix was easy so I went ahead and made it anyway.

I tested this on my own machine with CF 3.8.0-SNAPSHOT, built this morning.