### PR TITLE
Do not treat null fields as @Unconnected

### DIFF
--- a/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketAnnotatedTypeFactory.java
+++ b/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketAnnotatedTypeFactory.java
@@ -2,17 +2,19 @@ package org.checkerframework.checker.unconnectedsocket;
 
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.unconnectedsocket.qual.PossiblyConnected;
+import org.checkerframework.checker.unconnectedsocket.qual.Unconnected;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.javacutil.AnnotationBuilder;
 
 public class UnconnectedSocketAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
-  final AnnotationMirror TOP;
+  final AnnotationMirror TOP, BOTTOM;
 
   public UnconnectedSocketAnnotatedTypeFactory(BaseTypeChecker checker) {
     super(checker);
     TOP = AnnotationBuilder.fromClass(elements, PossiblyConnected.class);
+    BOTTOM = AnnotationBuilder.fromClass(elements, Unconnected.class);
     this.postInit();
   }
 }

--- a/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketChecker.java
+++ b/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketChecker.java
@@ -20,8 +20,7 @@ public class UnconnectedSocketChecker extends BaseTypeChecker {
     Properties messages = super.getMessagesProperties();
     messages.setProperty(
         "unconnected.field",
-        "This checker must treat all fields as @PossiblyConnected, for soundness. "
-            + "Remove any annotations you have written on this field.");
+        "@Unconnected is an invalid type for a field. Fields should only store possibly-connected sockets.");
     return messages;
   }
 }

--- a/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketVisitor.java
+++ b/unconnected-socket-checker/src/main/java/org/checkerframework/checker/unconnectedsocket/UnconnectedSocketVisitor.java
@@ -19,7 +19,7 @@ public class UnconnectedSocketVisitor
     VariableElement decl = TreeUtils.elementFromDeclaration(node);
     if (decl.getKind() == ElementKind.FIELD) {
       AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(node);
-      if (!type.hasAnnotation(atypeFactory.TOP)) {
+      if (type.hasExplicitAnnotation(atypeFactory.BOTTOM)) {
         checker.reportError(node, "unconnected.field");
       }
     }

--- a/unconnected-socket-checker/tests/unconnectedsocket/NullField.java
+++ b/unconnected-socket-checker/tests/unconnectedsocket/NullField.java
@@ -1,0 +1,9 @@
+// This test checks that extraneous unconnected.field errors aren't reported on
+// fields that are initialized to null, which was a problem with the original
+// implementation of that error.
+
+public class NullField {
+    public String foo = null;
+
+    public String bar;
+}

--- a/unconnected-socket-qual/src/main/java/org/checkerframework/checker/unconnectedsocket/qual/PossiblyConnected.java
+++ b/unconnected-socket-qual/src/main/java/org/checkerframework/checker/unconnectedsocket/qual/PossiblyConnected.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;

--- a/unconnected-socket-qual/src/main/java/org/checkerframework/checker/unconnectedsocket/qual/PossiblyConnected.java
+++ b/unconnected-socket-qual/src/main/java/org/checkerframework/checker/unconnectedsocket/qual/PossiblyConnected.java
@@ -4,8 +4,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * The top qualifier in the Unconnected Socket checker hierarchy. It can represent any expression,
@@ -17,5 +20,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @DefaultQualifierInHierarchy
+@DefaultFor(TypeUseLocation.FIELD)
 @SubtypeOf({})
 public @interface PossiblyConnected {}


### PR DESCRIPTION
Avoids a lot of false positive warnings like the test below in real code (I ran this on Zookeeper and saw these).