### PR TITLE
Handle non-source code differently when checking pseudo-assignments

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -115,7 +115,6 @@ class MustCallInvokedChecker {
           new LinkedHashSet<>(curBlockLocals.localSetInfo);
 
       for (Node node : nodes) {
-
         if (node instanceof AssignmentNode) {
           handleAssignment((AssignmentNode) node, newDefs);
         } else if (node instanceof ReturnNode) {
@@ -160,7 +159,10 @@ class MustCallInvokedChecker {
     if (mustCallVal.isEmpty()) {
       return;
     }
-    boolean assignedToOwning = false;
+    // Default to assuming that non-source nodes will always be assigned to
+    // an owning location, but that source nodes will not. This allows the checker
+    // to correctly handle foreach loops.
+    boolean assignedToOwning = !node.getInSource();
     AssignmentContext assignmentContext = node.getAssignmentContext();
     if (assignmentContext != null) {
       Element elementForType = assignmentContext.getElementForType();
@@ -237,9 +239,7 @@ class MustCallInvokedChecker {
         || callTree.getKind() == Tree.Kind.NEW_CLASS) {
       LocalVariableNode mustCallChoiceParam = getLocalPassedAsMustCallChoiceParam(node);
       if (mustCallChoiceParam != null) {
-        if (mustCallChoiceParam != null) {
-          return isVarInDefs(defs, mustCallChoiceParam);
-        }
+        return isVarInDefs(defs, mustCallChoiceParam);
       }
     }
     if (callTree.getKind() == Tree.Kind.METHOD_INVOCATION) {
@@ -712,7 +712,6 @@ class MustCallInvokedChecker {
           .noneMatch(localVarTree -> localVarWithTreeSet.contains(localVarTree))) {
         LocalVarWithTree firstlocalVarWithTree = localVarWithTreeSet.iterator().next();
         reportedMustCallErrors.add(firstlocalVarWithTree);
-
         checker.reportError(
             firstlocalVarWithTree.tree,
             "required.method.not.called",

--- a/object-construction-checker/tests/socket/EnhancedFor.java
+++ b/object-construction-checker/tests/socket/EnhancedFor.java
@@ -23,4 +23,14 @@ class EnhancedFor {
             } catch (IOException io) { }
         }
     }
+
+    void test3(List<Socket> list) {
+        // This error is issued because `s` is a local variable, and
+        // the foreach loop under the hood assigns the result of a call
+        // to Iterator#next into it (which is owning by default, because it's
+        // a method return type).
+        // :: error: required.method.not.called
+        for (Socket s : list) {
+        }
+    }
 }

--- a/object-construction-checker/tests/socket/EnhancedFor.java
+++ b/object-construction-checker/tests/socket/EnhancedFor.java
@@ -4,12 +4,23 @@ import java.util.List;
 import java.net.Socket;
 import java.io.IOException;
 
+import org.checkerframework.checker.objectconstruction.qual.Owning;
+
 class EnhancedFor {
     void test(List<Socket> list) {
         for (Socket s : list) {
             try {
                 s.close();
             } catch (IOException i) { }
+        }
+    }
+
+    void test2(List<Socket> list) {
+        for (int i = 0; i < list.size(); i++) {
+            Socket s = list.get(i);
+            try {
+                s.close();
+            } catch (IOException io) { }
         }
     }
 }

--- a/object-construction-checker/tests/socket/EnhancedFor.java
+++ b/object-construction-checker/tests/socket/EnhancedFor.java
@@ -1,0 +1,15 @@
+// Based on some false positives I found in ZK.
+
+import java.util.List;
+import java.net.Socket;
+import java.io.IOException;
+
+class EnhancedFor {
+    void test(List<Socket> list) {
+        for (Socket s : list) {
+            try {
+                s.close();
+            } catch (IOException i) { }
+        }
+    }
+}


### PR DESCRIPTION
This prevents warnings from being issued in non-source locations, which are really hard to interpret. Without this, the new case case issues a `required.method.not.called` error for the entire class due to the foreach loop, which is useless to the user.

I don't think there are any generated elements that won't be assigned into a local variable, but I might not be remembering something.