### PR TITLE
Handle ternary expressions

### DIFF
--- a/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
@@ -317,7 +317,10 @@ class ACRegularExitPointTest {
         foo.a();
     }
 
-    void testTernary(boolean b) {
+    /**
+     * cases where ternary expressions are assigned to a variable
+     */
+    void testTernaryAssigned(boolean b) {
         Foo ternary1 = b ? new Foo() : makeFoo();
         ternary1.a();
 
@@ -329,21 +332,48 @@ class ACRegularExitPointTest {
         Foo ternary3 = b ? new Foo() : x;
         ternary3.a();
 
-        // :: error: required.method.not.called
-        if ((b ? new Foo() : null) != null) {
-            b = !b;
-        }
-        // :: error: required.method.not.called
-        if ((b ? makeFoo() : null) != null) {
-            b = !b;
-        }
-
         takeOwnership(b ? new Foo() : makeFoo());
 
         // :: error: required.method.not.called
         Foo x2 = new Foo();
         takeOwnership(b ? x2 : null);
 
+        int i = 10;
+        Foo ternaryInLoop = null;
+        while (i > 0) {
+            // :: error: required.method.not.called
+            ternaryInLoop = b ? null : new Foo();
+            i--;
+        }
+        ternaryInLoop.a();
+    }
+
+    /**
+     * tests where ternary and cast expressions (possibly nested) may or may not be assigned to a variable
+     */
+    void testTernaryCastUnassigned(boolean b) {
+        // :: error: required.method.not.called
+        if ((b ? new Foo() : null) != null) {
+            b = !b;
+        }
+
+        // :: error: required.method.not.called
+        if ((b ? makeFoo() : null) != null) {
+            b = !b;
+        }
+
+        // :: error: required.method.not.called
+        if (((Foo) new Foo()) != null) {
+            b = !b;
+        }
+
+        // double cast; no error
+        Foo doubleCast = (Foo) ((Foo) makeFoo());
+        doubleCast.a();
+
+        // nesting casts and ternary expressions; no error
+        Foo deepNesting = (b ? (!b ? makeFoo() : (Foo) makeFoo()) : ((Foo) new Foo()));
+        deepNesting.a();
     }
 
     @Owning Foo testTernaryReturnOk(boolean b) {

--- a/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
@@ -362,6 +362,12 @@ class ACRegularExitPointTest {
             b = !b;
         }
 
+        Foo x = new Foo();
+        if ((b ? x : null) != null) {
+            b = !b;
+        }
+        x.a();
+
         // :: error: required.method.not.called
         if (((Foo) new Foo()) != null) {
             b = !b;

--- a/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
@@ -312,4 +312,48 @@ class ACRegularExitPointTest {
         // :: error: required.method.not.called
         SubFoo f = new SubFoo();
     }
+
+    static void takeOwnership(@Owning Foo foo) {
+        foo.a();
+    }
+
+    void testTernary(boolean b) {
+        Foo ternary1 = b ? new Foo() : makeFoo();
+        ternary1.a();
+
+        // :: error: required.method.not.called
+        Foo ternary2 = b ? new Foo() : makeFoo();
+
+        // :: error: required.method.not.called
+        Foo x = new Foo();
+        Foo ternary3 = b ? new Foo() : x;
+        ternary3.a();
+
+        // :: error: required.method.not.called
+        if ((b ? new Foo() : null) != null) {
+            b = !b;
+        }
+        // :: error: required.method.not.called
+        if ((b ? makeFoo() : null) != null) {
+            b = !b;
+        }
+
+        takeOwnership(b ? new Foo() : makeFoo());
+
+        // :: error: required.method.not.called
+        Foo x2 = new Foo();
+        takeOwnership(b ? x2 : null);
+
+    }
+
+    @Owning Foo testTernaryReturnOk(boolean b) {
+        return b ? new Foo() : makeFoo();
+    }
+
+    @Owning Foo testTernaryReturnBad(boolean b) {
+        // :: error: required.method.not.called
+        Foo x = new Foo();
+        return b ? x : makeFoo();
+    }
+
 }

--- a/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
@@ -386,4 +386,13 @@ class ACRegularExitPointTest {
         return b ? x : makeFoo();
     }
 
+    @MustCall("toString") static class Sub1 extends Object { }
+    @MustCall("clone") static class Sub2 extends Object { }
+
+    static void test_ternary(boolean b) {
+        // :: error: required.method.not.called
+        Object toStringAndClone = b ? new Sub1() : new Sub2();
+        // at this point, for soundness, we should be responsible for calling both toString and clone on obj...
+        toStringAndClone.toString();
+    }
 }


### PR DESCRIPTION
At a high level, the handling is similar to type casts.  Handling ternary expressions on the RHS of an assignment to some local variable `x` requires some care.  If an operand is a method call, we can treat it as if it were just normally being assigned to `x`, since whenever that expression branch executes, the result of the call is assigned to `x`.  But if an operand is a local variable `y`, we should _not_ do ownership transfer, as that branch of the expression is only executed conditionally and it is possible that `y` is not copied to `x`.

There is also some refactored code to handle ternary expressions and casts nested within each other; deeply-nested casts led to false positives before.  See changes to `ACRegularExitPoint` for the new tests.