### PR TITLE
Add null check for successor block

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -299,15 +299,17 @@ class MustCallInvokedChecker {
       return false;
     }
     Block successorBlock = ((SingleSuccessorBlock) node.getBlock()).getSuccessor();
-    List<Node> succNodes = successorBlock.getNodes();
-    if (succNodes.size() > 0) {
-      Node succNode = succNodes.get(0);
-      if (succNode instanceof TypeCastNode) {
-        return ((TypeCastNode) succNode).getOperand().equals(node);
-      } else if (succNode instanceof TernaryExpressionNode) {
-        TernaryExpressionNode ternaryExpressionNode = (TernaryExpressionNode) succNode;
-        return ternaryExpressionNode.getThenOperand().equals(node)
-            || ternaryExpressionNode.getElseOperand().equals(node);
+    if (successorBlock != null) {
+      List<Node> succNodes = successorBlock.getNodes();
+      if (succNodes.size() > 0) {
+        Node succNode = succNodes.get(0);
+        if (succNode instanceof TypeCastNode) {
+          return ((TypeCastNode) succNode).getOperand().equals(node);
+        } else if (succNode instanceof TernaryExpressionNode) {
+          TernaryExpressionNode ternaryExpressionNode = (TernaryExpressionNode) succNode;
+          return ternaryExpressionNode.getThenOperand().equals(node)
+              || ternaryExpressionNode.getElseOperand().equals(node);
+        }
       }
     }
     return false;


### PR DESCRIPTION
`SingleSuccessorBlock.getSuccessor()` has a `@Nullable` return value, so we need this check.  We observed NPEs when analyzing real code