### PR TITLE
FileDescriptor problem

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Stream.astub
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Stream.astub
@@ -26,6 +26,7 @@ class DataOutputStream extends FilterOutputStream implements DataOutput {
 
 class RandomAccessFile {
     @MustCallChoice FileChannel getChannel(@MustCallChoice RandomAccessFile this);
+    @MustCallChoice FileDescriptor getFD(@MustCallChoice RandomAccessFile this) throws IOException;
 }
 
 class OutputStream { }
@@ -118,30 +119,28 @@ class BufferedInputStream extends FilterInputStream {
 }
 
 class FileOutputStream extends OutputStream {
+    // This constructor actually opens a new file (note that java.io.File doesn't need to be closed)
+    // and creates a new obligation.
     FileOutputStream(String arg0) throws FileNotFoundException;
     FileOutputStream(String arg0, boolean arg1) throws FileNotFoundException;
     FileOutputStream(File arg0) throws FileNotFoundException;
     FileOutputStream(File arg0, boolean arg1) throws FileNotFoundException;
-    FileOutputStream(FileDescriptor arg0);
-    void write(int arg0) throws IOException;
-    void write(byte[] arg0) throws IOException;
-    void write(byte[] arg0, int arg1, int arg2) throws IOException;
-    void close() throws IOException;
-    FileDescriptor getFD() throws IOException;
+
+    // These do not - they create aliases to an existing, open file.
+    @MustCallChoice FileOutputStream(@MustCallChoice FileDescriptor arg0);
+    @MustCallChoice FileDescriptor getFD(@MustCallChoice FileOutputStream this) throws IOException;
     @MustCallChoice FileChannel getChannel(@MustCallChoice FileOutputStream this);
 }
 
 class FileInputStream extends InputStream {
+    // This constructor actually opens a new file (note that java.io.File doesn't need to be closed)
+    // and creates a new obligation.
     FileInputStream(String arg0) throws FileNotFoundException;
     FileInputStream(File arg0) throws FileNotFoundException;
-    FileInputStream(FileDescriptor arg0);
-    int read() throws IOException;
-    int read(byte[] arg0) throws IOException;
-    int read(byte[] arg0, int arg1, int arg2) throws IOException;
-    long skip(long arg0) throws IOException;
-    int available() throws IOException;
-    void close() throws IOException;
-    FileDescriptor getFD() throws IOException;
+
+    // These do not - they create aliases to an existing, open file.
+    @MustCallChoice FileInputStream(@MustCallChoice FileDescriptor arg0);
+    @MustCallChoice FileDescriptor getFD(@MustCallChoice FileInputStream this) throws IOException;
     @MustCallChoice FileChannel getChannel(@MustCallChoice FileInputStream this);
 }
 

--- a/must-call-checker/tests/mustcall/FileDescriptors.java
+++ b/must-call-checker/tests/mustcall/FileDescriptors.java
@@ -1,0 +1,19 @@
+// A test for some issues related to the getFD() method in RandomAccessFile.
+
+import java.io.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+class FileDescriptors {
+    void test(@Owning RandomAccessFile r) throws Exception {
+        @MustCall("close") FileDescriptor fd = r.getFD();
+        // :: error: assignment.type.incompatible
+        @MustCall({}) FileDescriptor fd2 = r.getFD();
+    }
+
+    void test2(@Owning RandomAccessFile r) throws Exception {
+        @MustCall("close") FileInputStream f = new FileInputStream(r.getFD());
+        // :: error: assignment.type.incompatible
+        @MustCall({}) FileInputStream f2 = new FileInputStream(r.getFD());
+    }
+}

--- a/object-construction-checker/tests/socket/FileDescriptorTest.java
+++ b/object-construction-checker/tests/socket/FileDescriptorTest.java
@@ -1,0 +1,34 @@
+import java.io.*;
+import java.io.IOException;
+
+import java.net.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+public class FileDescriptorTest
+{
+    public static void readPropertiesFile(File from) throws IOException {
+        RandomAccessFile file = new RandomAccessFile(from, "rws");
+        FileInputStream in = null;
+        try {
+            in = new FileInputStream(file.getFD());
+            file.seek(0);
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+            file.close();
+        }
+    }
+
+    public static void sameScenario_noFD(@Owning Socket sock) throws IOException {
+        InputStream in = null;
+        try {
+            in = sock.getInputStream();
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+            sock.close();
+        }
+    }
+}

--- a/object-construction-checker/tests/socket/FileDescriptorTest.java
+++ b/object-construction-checker/tests/socket/FileDescriptorTest.java
@@ -6,7 +6,11 @@ import org.checkerframework.checker.objectconstruction.qual.*;
 
 public class FileDescriptorTest
 {
+    // This is the original test case. It fails because `in.close()` might throw an exception, which is
+    // not caught; therefore, file might still be open.
     public static void readPropertiesFile(File from) throws IOException {
+        // This is a false positive.
+        // :: error: required.method.not.called
         RandomAccessFile file = new RandomAccessFile(from, "rws");
         FileInputStream in = null;
         try {
@@ -20,6 +24,10 @@ public class FileDescriptorTest
         }
     }
 
+    // This is a similar test to the above, but without using the indirection through getFD().
+    // This test case demonstrates that the problem is not related to getFD().
+    // This warning is a false positive, and should be resolved at the same time as the warning above.
+    // :: error: required.method.not.called
     public static void sameScenario_noFD(@Owning Socket sock) throws IOException {
         InputStream in = null;
         try {
@@ -29,6 +37,18 @@ public class FileDescriptorTest
                 in.close();
             }
             sock.close();
+        }
+    }
+
+    // This version, written by Narges, does not issue a false positive.
+    public static void readPropertiesFile_noFP(File from) throws IOException {
+        RandomAccessFile file = new RandomAccessFile(from, "rws");
+        FileInputStream in = null;
+        try {
+            in = new FileInputStream(file.getFD());
+            in.close();
+        } catch (IOException e){
+            file.close();
         }
     }
 }


### PR DESCRIPTION
@msridhar @Nargeshdb I looked into the issue with `FileDescriptor`s we discussed on our call yesterday. Thanks to @Nargeshdb for putting together a test case.

I wrote stubs that I think are correct wrt FDs, and included them here. The MC checker is handling them correctly (see the test case I wrote for it) as far as I can tell.

That said, the original test that @Nargeshdb wrote is still failing. I believe the reason isn't related to there being a `FileDescriptor` - see the version of the test that I added that only uses `Closeable` objects, which also fails.

The failure looks like this:
```
object-construction-checker/tests/socket/FileDescriptorTest.java:10: error: [required.method.not.called] @MustCall method(s) close,  for variable/expression not invoked.  The type of object is: java.io.RandomAccessFile.  Reason for going out of scope: possible exceptional exit due to in.close() with exception type java.io.IOException
        RandomAccessFile file = new RandomAccessFile(from, "rws");
                         ^
```

Note that this is due to the possible exceptional exit from calling `close` on `in`, which IIRC you all told me should be ignored.

Thoughts?