### PR TITLE
fix crash in try-with-resources encountered by Narges in hfds

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -118,11 +118,13 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
    * Returns the same annotation mirror if the input annotation didn't have "close" as one of its
    * element.
    *
+   * <p>The argument is permitted to be null. If it is null, then bottom is returned.
+   *
    * <p>Package private to permit usage from the visitor in the common assignment check.
    */
-  /* package-private */ AnnotationMirror withoutClose(AnnotationMirror anno) {
+  /* package-private */ AnnotationMirror withoutClose(@Nullable AnnotationMirror anno) {
     // shortcut for easy paths
-    if (AnnotationUtils.areSame(anno, BOTTOM)) {
+    if (anno == null || AnnotationUtils.areSame(anno, BOTTOM)) {
       return BOTTOM;
     } else if (!AnnotationUtils.areSameByClass(anno, MustCall.class)) {
       return anno;

--- a/must-call-checker/tests/mustcall/TryWithResourcesCrash.java
+++ b/must-call-checker/tests/mustcall/TryWithResourcesCrash.java
@@ -1,0 +1,29 @@
+// A test case for a crash that Narges encountered while checking hfds.
+
+import java.io.DataOutputStream;
+        import java.io.OutputStream;
+        import java.io.Closeable;
+        import java.io.IOException;
+
+class TryWithResourcesCrash {
+    void test(FileSystem fs, byte[] bytes, String path) throws IOException {
+        try (FSDataOutputStream out = fs.createFile(path).overwrite(true).build()) {
+            out.write(bytes);
+        }
+    }
+
+    class FSDataOutputStream extends DataOutputStream {
+        FSDataOutputStream(OutputStream os) {
+            super(os);
+        }
+    }
+
+    abstract class FSDataOutputStreamBuilder<S extends FSDataOutputStream, B extends FSDataOutputStreamBuilder<S, B>> {
+        abstract S build();
+        abstract B overwrite(boolean b);
+    }
+
+    abstract class FileSystem implements Closeable {
+        abstract FSDataOutputStreamBuilder createFile (String s);
+    }
+}


### PR DESCRIPTION
I spent a bit of time trying to figure out why `MustCallVisitor` was passing `null`, but didn't find anything wrong with what it's doing - it's just calling `getAnnotationInHierarchy` in the common assignment check on the types it was passed, which is returning null in this case.

I'm not sure if this might be indicative of a bug in the CF, but this solution handles the problem on our end and should allow us to avoid unnecessary crashes in our case study.