### PR TITLE
Fix crash in Zookeeper

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -146,7 +146,12 @@ class MustCallInvokedChecker {
 
   private void handleTernary(Node node, Set<ImmutableSet<LocalVarWithTree>> defs) {
     LocalVariableNode ternaryLocal = typeFactory.getTempVarForTree(node);
-
+    // This can happen when one side of the ternary is null, I think.
+    // Without this, we get a crash in tests/mustcall/ZookeeperTernaryCrash.java
+    // on the only ternary in that program snippet.
+    if (ternaryLocal == null) {
+      return;
+    }
     // First check then operand
     Node operand = removeCasts(((TernaryExpressionNode) node).getThenOperand());
     LocalVariableNode operandLocal = typeFactory.getTempVarForTree(operand);
@@ -996,7 +1001,7 @@ class MustCallInvokedChecker {
 
     List<String> mustCallValue = typeFactory.getMustCallValue(localVarWithTreeSet, mcStore);
     // optimization: if there are no must-call methods, we do not need to perform the check
-    if (mustCallValue.isEmpty()) {
+    if (mustCallValue == null || mustCallValue.isEmpty()) {
       return;
     }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -92,7 +92,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
    *     then the default MustCall type of each variable's class will be used.
    * @return the list of must-call method names
    */
-  public List<String> getMustCallValue(
+  public @Nullable List<String> getMustCallValue(
       ImmutableSet<LocalVarWithTree> localVarWithTreeSet, @Nullable CFStore mcStore) {
     MustCallAnnotatedTypeFactory mustCallAnnotatedTypeFactory =
         getTypeFactoryOfSubchecker(MustCallChecker.class);
@@ -119,10 +119,15 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
       // can; that would probably require us to change the Must Call Checker to also
       // track temporaries.
       if (mcAnno == null) {
-        mcAnno =
-            mustCallAnnotatedTypeFactory
-                .getAnnotatedType(TypesUtils.getTypeElement(local.getType()))
-                .getAnnotationInHierarchy(mustCallAnnotatedTypeFactory.TOP);
+        Element typeElt = TypesUtils.getTypeElement(local.getType());
+        if (typeElt == null) {
+          mcAnno = mustCallAnnotatedTypeFactory.TOP;
+        } else {
+          mcAnno =
+              mustCallAnnotatedTypeFactory
+                  .getAnnotatedType(typeElt)
+                  .getAnnotationInHierarchy(mustCallAnnotatedTypeFactory.TOP);
+        }
       }
       mcLub = mustCallAnnotatedTypeFactory.getQualifierHierarchy().leastUpperBound(mcLub, mcAnno);
     }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -109,7 +109,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
         mcAnno =
             value.getAnnotations().stream()
                 .filter(anno -> AnnotationUtils.areSameByClass(anno, MustCall.class))
-                .findAny().orElse(null);
+                .findAny()
+                .orElse(null);
       }
       // If it wasn't in the store, fall back to the default must-call type for the class.
       // TODO: we currently end up in this case when checking a call to the return type

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -109,8 +109,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
         mcAnno =
             value.getAnnotations().stream()
                 .filter(anno -> AnnotationUtils.areSameByClass(anno, MustCall.class))
-                .findAny()
-                .get();
+                .findAny().orElse(null);
       }
       // If it wasn't in the store, fall back to the default must-call type for the class.
       // TODO: we currently end up in this case when checking a call to the return type

--- a/object-construction-checker/tests/mustcall/ZookeeperTernaryCrash.java
+++ b/object-construction-checker/tests/mustcall/ZookeeperTernaryCrash.java
@@ -1,0 +1,74 @@
+import java.util.*;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateParsingException;
+
+final class ZookeeperTernaryCrash {
+
+    private static List<SubjectName> getSubjectAltNames(final X509Certificate cert) {
+        try {
+            final Collection<List<?>> entries = cert.getSubjectAlternativeNames();
+            if (entries == null) {
+                return Collections.emptyList();
+            }
+            final List<SubjectName> result = new ArrayList<SubjectName>();
+            for (List<?> entry : entries) {
+                // This warning is caused by the wildcard, for sure, though I'm
+                // not sure if it is a false positive or not.
+                // :: warning: cast.unsafe
+                final Integer type = entry.size() >= 2 ? (Integer) entry.get(0) : null;
+                if (type != null) {
+                    if (type == SubjectName.DNS || type == SubjectName.IP) {
+                        final Object o = entry.get(1);
+                        if (o instanceof String) {
+                            result.add(new SubjectName((String) o, type));
+                        } else if (o instanceof byte[]) {
+                            // TODO ASN.1 DER encoded form
+                        }
+                    }
+                }
+            }
+            return result;
+        } catch (final CertificateParsingException ignore) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class SubjectName {
+
+        static final int DNS = 2;
+        static final int IP = 7;
+
+        private final String value;
+        private final int type;
+
+        static SubjectName IP(final String value) {
+            return new SubjectName(value, IP);
+        }
+
+        static SubjectName DNS(final String value) {
+            return new SubjectName(value, DNS);
+        }
+
+        SubjectName(final String value, final int type) {
+            if (type != DNS && type != IP) {
+                throw new IllegalArgumentException("Invalid type: " + type);
+            }
+            this.value = Objects.requireNonNull(value);
+            this.type = type;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+    }
+}


### PR DESCRIPTION
Fix is easy, and the crash would be hard to repro, so this is just the fix. I can try to minimize the failure if we think it's critical to have a unit test. Stack trace started with:

```
  Exception: java.util.NoSuchElementException: No value present; java.util.NoSuchElementExc\
eption: No value present
        at java.util.Optional.get(Optional.java:135)
        at org.checkerframework.checker.objectconstruction.ObjectConstructionAnnotatedTypeF\
actory.getMustCallValue(ObjectConstructionAnnotatedTypeFactory.java:113)
        at org.checkerframework.checker.objectconstruction.MustCallInvokedChecker.checkMust\
Call(MustCallInvokedChecker.java:997)
        at org.checkerframework.checker.objectconstruction.MustCallInvokedChecker.handleSuc\
cessorBlocks(MustCallInvokedChecker.java:898)
        at org.checkerframework.checker.objectconstruction.MustCallInvokedChecker.checkMust\
CallInvoked(MustCallInvokedChecker.java:143)
        at org.checkerframework.checker.objectconstruction.ObjectConstructionAnnotatedTypeF\
actory.postAnalyze(ObjectConstructionAnnotatedTypeFactory.java:79)
        at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.analyze(GenericA\
nnotatedTypeFactory.java:1506)
        at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.performFlowAnaly\
sis(GenericAnnotatedTypeFactory.java:1352)
        at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.checkAndPerformF\
lowAnalysis(GenericAnnotatedTypeFactory.java:1783)
        at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.preProcessClassT\
ree(GenericAnnotatedTypeFactory.java:386)
```