### PR TITLE
Respect -AonlyUses

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -233,7 +233,8 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         AnnotationMirror writtenMCAnno = type.getAnnotationInHierarchy(this.TOP);
         if (writtenMCAnno != null
             && !this.getQualifierHierarchy().isSubtype(inheritedMCAnno, writtenMCAnno)) {
-          if (!elementsIssuedInconsistentMustCallSubtypeErrors.contains(elt)) {
+          if (!elementsIssuedInconsistentMustCallSubtypeErrors.contains(elt)
+              && !this.checker.shouldSkipUses(elt)) {
             checker.reportError(
                 elt,
                 "inconsistent.mustcall.subtype",

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -621,12 +621,14 @@ class MustCallInvokedChecker {
 
     if (!calledMethodsSatisfyMustCall(mcValues, cmAnno)) {
       Element lhsElement = TreeUtils.elementFromTree(lhs.getTree());
-      checker.reportError(
-          node.getTree(),
-          "required.method.not.called",
-          formatMissingMustCallMethods(mcValues),
-          lhsElement.asType().toString(),
-          " Non-final owning field might be overwritten");
+      if (!checker.shouldSkipUses(lhsElement)) {
+        checker.reportError(
+            node.getTree(),
+            "required.method.not.called",
+            formatMissingMustCallMethods(mcValues),
+            lhsElement.asType().toString(),
+            " Non-final owning field might be overwritten");
+      }
     }
   }
 
@@ -1031,13 +1033,15 @@ class MustCallInvokedChecker {
       if (reportedMustCallErrors.stream()
           .noneMatch(localVarTree -> localVarWithTreeSet.contains(localVarTree))) {
         LocalVarWithTree firstlocalVarWithTree = localVarWithTreeSet.iterator().next();
-        reportedMustCallErrors.add(firstlocalVarWithTree);
-        checker.reportError(
-            firstlocalVarWithTree.tree,
-            "required.method.not.called",
-            formatMissingMustCallMethods(mustCallValue),
-            firstlocalVarWithTree.localVar.getType().toString(),
-            outOfScopeReason);
+        if (!checker.shouldSkipUses(TreeUtils.elementFromTree(firstlocalVarWithTree.tree))) {
+          reportedMustCallErrors.add(firstlocalVarWithTree);
+          checker.reportError(
+              firstlocalVarWithTree.tree,
+              "required.method.not.called",
+              formatMissingMustCallMethods(mustCallValue),
+              firstlocalVarWithTree.localVar.getType().toString(),
+              outOfScopeReason);
+        }
       }
     }
   }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -90,6 +90,11 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
    * guaranteeing that the {@code @MustCall} obligation of the field will be satisfied.
    */
   private void checkFinalOwningField(Element field) {
+
+    if (checker.shouldSkipUses(field)) {
+      return;
+    }
+
     List<String> fieldMCAnno = atypeFactory.getMustCallValue(field);
     String error = "";
 

--- a/object-construction-checker/src/test/java/tests/MustCallOnlyJDKTest.java
+++ b/object-construction-checker/src/test/java/tests/MustCallOnlyJDKTest.java
@@ -1,0 +1,26 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.objectconstruction.ObjectConstructionChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+public class MustCallOnlyJDKTest extends CheckerFrameworkPerDirectoryTest {
+  public MustCallOnlyJDKTest(List<File> testFiles) {
+    super(
+        testFiles,
+        ObjectConstructionChecker.class,
+        "mustcall",
+        "-Anomsgtext",
+        "-AcheckMustCall",
+        "-AcountMustCall",
+        "-AonlyUses=^java\\.",
+        "-nowarn");
+  }
+
+  @Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"mustcall-onlyjdk"};
+  }
+}

--- a/object-construction-checker/tests/mustcall-onlyjdk/OnlyJDK.java
+++ b/object-construction-checker/tests/mustcall-onlyjdk/OnlyJDK.java
@@ -1,0 +1,76 @@
+// A test that some custom error reporting mechanisms respect the -AonlyUses command line option.
+
+import java.io.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import java.nio.ByteBuffer;
+
+class OnlyJDK {
+    @MustCall("a")
+    class Foo {
+        void a() {}
+    }
+
+    void test_custom() {
+        // normally, a required.method.not.called error would be issued here
+        Foo foo = new Foo();
+    }
+
+    void test_jdk(String fn) throws FileNotFoundException {
+        // :: error: required.method.not.called
+        new FileInputStream(fn);
+    }
+
+    // This class copied from tests/mustcall/ZookeeperByteBufferInputStream.java
+    @MustCall({})
+    // normally, an inconsistent.mustcall.subtype error would be issued here
+    class ZookeeperByteBufferInputStream extends InputStream {
+
+        ByteBuffer bb;
+
+        // :: error: super.invocation.invalid
+        public ZookeeperByteBufferInputStream(ByteBuffer bb) {
+            this.bb = bb;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (bb.remaining() == 0) {
+                return -1;
+            }
+            return bb.get() & 0xff;
+        }
+
+        @Override
+        public int available() throws IOException {
+            return bb.remaining();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (bb.remaining() == 0) {
+                return -1;
+            }
+            if (len > bb.remaining()) {
+                len = bb.remaining();
+            }
+            bb.get(b, off, len);
+            return len;
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            return read(b, 0, b.length);
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            if (n < 0L) {
+                return 0;
+            }
+            n = Math.min(n, bb.remaining());
+            bb.position(bb.position() + (int) n);
+            return n;
+        }
+    }
+}


### PR DESCRIPTION
My intuition this afternoon that we'd need to write code to make our checker respect `-AonlyUses=` was correct (even if I named this branch wrong...): our custom error reporting doesn't go through the common assignment check, which is where that functionality is implemented.

I tried using `-AonlyUses=^java\.` on Zookeeper, which only removed 7 errors - far too small - so I investigated a bit and discovered this issue. This change adds a simple test case that uses that exact option, too, for extra fun. I tried to be efficient with the placement of the check, but in most cases it was easier to place the check right at the point where the error will be issued. This code path is only used in error reporting, so the impact on perf should be minimal regardless.

I ran `./gradlew clean build` locally successfully.