### PR TITLE
permit socket factories to produce unconnected sockets

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Socket.astub
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Socket.astub
@@ -125,7 +125,7 @@ class SSLServerSocket { }
 package javax.net;
 
 class SocketFactory {
-    @Owning Socket createSocket() throws IOException;
+    @Owning @MustCall({}) Socket createSocket() throws IOException;
     @Owning Socket createSocket(String arg0, int arg1) throws IOException, UnknownHostException;
     @Owning Socket createSocket(String arg0, int arg1, InetAddress arg2, int arg3) throws IOException, UnknownHostException;
     @Owning Socket createSocket(InetAddress arg0, int arg1) throws IOException;


### PR DESCRIPTION
This API is used by Zookeeper.