### PR TITLE
ignore some more exceptions, plus document our assumptions about ignored exceptions

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -1075,12 +1075,20 @@ class MustCallInvokedChecker {
    * in the JVM, like OutOfMemoryErrors or ClassCircularityErrors.
    */
   private static boolean isIgnoredExceptionType(@FullyQualifiedName Name exceptionClassName) {
+    // any method call has a CFG edge for Throwable to represent run-time misbehavior. Ignore it.
     return exceptionClassName.contentEquals(Throwable.class.getCanonicalName())
+        // use the Nullness Checker to prove this won't happen
         || exceptionClassName.contentEquals(NullPointerException.class.getCanonicalName())
+        // these errors can't be predicted statically, so we'll ignore them and assume they won't
+        // happen
         || exceptionClassName.contentEquals(ClassCircularityError.class.getCanonicalName())
         || exceptionClassName.contentEquals(ClassFormatError.class.getCanonicalName())
         || exceptionClassName.contentEquals(NoClassDefFoundError.class.getCanonicalName())
-        || exceptionClassName.contentEquals(OutOfMemoryError.class.getCanonicalName());
+        || exceptionClassName.contentEquals(OutOfMemoryError.class.getCanonicalName())
+        // it's not our problem if the Java type system is wrong
+        || exceptionClassName.contentEquals(ClassCastException.class.getCanonicalName())
+        // it's not our problem if the code is going to divide by zero.
+        || exceptionClassName.contentEquals(ArithmeticException.class.getCanonicalName());
   }
 
   /**


### PR DESCRIPTION
These show up in one place is Zookeeper, where the code divides by a non-zero constant and then casts the result to `int`.