### PR TITLE
use MCC for SSLSocketFactory

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Socket.astub
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Socket.astub
@@ -114,8 +114,8 @@ import org.checkerframework.checker.objectconstruction.qual.*;
 import org.checkerframework.common.returnsreceiver.qual.*;
 
 class SSLSocketFactory extends SocketFactory {
-    Socket createSocket(@Owning Socket arg0, String arg1, int arg2, boolean arg3) throws IOException;
-    Socket createSocket(@Owning Socket arg0, InputStream arg1, boolean arg2) throws IOException;
+    @MustCallChoice Socket createSocket(@MustCallChoice Socket arg0, String arg1, int arg2, boolean arg3) throws IOException;
+    @MustCallChoice Socket createSocket(@MustCallChoice Socket arg0, InputStream arg1, boolean arg2) throws IOException;
 }
 
 class SSLSocket { }


### PR DESCRIPTION
based on the docs here: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/SSLSocketFactory.html#createSocket(java.net.Socket,java.io.InputStream,boolean)

These methods modify the options of the existing socket; they're not taking ownership but creating a resource alias/MCC situation.