### PR TITLE
don't warn on method invocations whose return types are MCC with owning fields

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -336,9 +336,10 @@ class MustCallInvokedChecker {
 
   /**
    * Checks for cases where we do not need to track a method. We can skip the check when the method
-   * invocation is a call to "this" or a super constructor call, or when the method's return type is
-   * non-owning, which can either be because the method has no return type or because it is
-   * annotated with {@link NotOwning}.
+   * invocation is a call to "this" or a super constructor call, when the method's return type is
+   * annotated with MustCallChoice and the argument in the corresponding position is an owning
+   * field, or when the method's return type is non-owning, which can either be because the method
+   * has no return type or because it is annotated with {@link NotOwning}.
    */
   private boolean shouldSkipInvokeCheck(Node node) {
     Tree callTree = node.getTree();
@@ -346,9 +347,29 @@ class MustCallInvokedChecker {
       MethodInvocationTree methodInvokeTree = (MethodInvocationTree) callTree;
       return TreeUtils.isSuperConstructorCall(methodInvokeTree)
           || TreeUtils.isThisConstructorCall(methodInvokeTree)
+          || returnTypeIsMustCallChoiceWithOwningField((MethodInvocationNode) node)
           || hasNotOwningReturnType((MethodInvocationNode) node);
     }
     return false;
+  }
+
+  /**
+   * Returns true if this node represents a method invocation of a must-call choice method, where
+   * the other must call choice is an owning field.
+   *
+   * @param node a method invocation node
+   * @return if this is the invocation of a method whose return type is MCC with an owning field
+   */
+  private boolean returnTypeIsMustCallChoiceWithOwningField(MethodInvocationNode node) {
+    Node mccParam = getVarOrTempVarPassedAsMustCallChoiceParam(node);
+    if (mccParam == null) {
+      return false;
+    }
+    if (!(mccParam instanceof FieldAccessNode)) {
+      return false;
+    }
+    FieldAccessNode faNode = (FieldAccessNode) mccParam;
+    return typeFactory.getDeclAnnotation(faNode.getElement(), Owning.class) != null;
   }
 
   /**

--- a/object-construction-checker/tests/socket/MCCOwningField.java
+++ b/object-construction-checker/tests/socket/MCCOwningField.java
@@ -1,0 +1,27 @@
+// A test case for a common pattern in Zookeeper: something is must-call-choice
+// with an owning field, and therefore a false positive was issued.
+
+import java.net.Socket;
+
+import org.checkerframework.checker.objectconstruction.qual.Owning;
+import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+@MustCall("stop")
+class MCCOwningField {
+
+    @Owning final Socket s;
+
+    MCCOwningField() throws Exception {
+        s = new Socket();
+    }
+
+    void simple() throws Exception {
+        s.getInputStream();
+    }
+
+    @EnsuresCalledMethods(value="s", methods="close")
+    void stop() throws Exception {
+        s.close();
+    }
+}


### PR DESCRIPTION
Note that this makes us unable to verify closing a must-call field through its resource-aliases, but I've never seen that pattern in practice.