### PR TITLE
Various fixes to ResetMustCall/constructors

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -48,6 +48,7 @@ import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.dataflow.cfg.node.NullLiteralNode;
 import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
 import org.checkerframework.dataflow.cfg.node.TernaryExpressionNode;
@@ -593,14 +594,29 @@ class MustCallInvokedChecker {
     }
 
     FieldAccessNode lhs = (FieldAccessNode) lhsNode;
-
     Node receiver = lhs.getReceiver();
-    // Check that there is a corresponding resetMustCall annotation, unless this is an
-    // assignment to a field of a newly-declared local variable that can't be in scope
-    // for the containing method.
+
+    // TODO: it would be better to defer getting the path until after we check
+    // for a ResetMustCall annotation, because getting the path can be expensive.
+    // It might be possible to exploit the CFG structure to find the containing
+    // method (rather than using the path, as below), because if a method is being
+    // analyzed then it should be the root of the CFG (I think).
+    TreePath currentPath = typeFactory.getPath(node.getTree());
+    MethodTree enclosingMethod = TreePathUtil.enclosingMethod(currentPath);
+
+    if (enclosingMethod == null) {
+      // Assignments outside of methods must be field initializers, which
+      // are always safe.
+      return;
+    }
+
+    // Check that there is a corresponding resetMustCall annotation, unless this is
+    // 1) an assignment to a field of a newly-declared local variable that can't be in scope
+    // for the containing method, 2) the rhs is a null literal (so there's nothing to reset).
     if (!(receiver instanceof LocalVariableNode
-        && isVarInDefs(newDefs, (LocalVariableNode) receiver))) {
-      checkEnclosingMethodIsResetMC(node);
+            && isVarInDefs(newDefs, (LocalVariableNode) receiver))
+        && !(node.getExpression() instanceof NullLiteralNode)) {
+      checkEnclosingMethodIsResetMC(node, enclosingMethod, currentPath);
     }
 
     MustCallAnnotatedTypeFactory mcTypeFactory =
@@ -642,25 +658,19 @@ class MustCallInvokedChecker {
    * whose target is the object whose field is being re-assigned.
    *
    * @param node an assignment node whose lhs is a non-final, owning field
+   * @param enclosingMethod the MethodTree in which the re-assignment takes place
+   * @param currentPath the currentPath
    */
-  private void checkEnclosingMethodIsResetMC(AssignmentNode node) {
+  private void checkEnclosingMethodIsResetMC(
+      AssignmentNode node, MethodTree enclosingMethod, TreePath currentPath) {
     Node lhs = node.getTarget();
     if (!(lhs instanceof FieldAccessNode)) {
       return;
     }
 
     String receiverString = receiverAsString((FieldAccessNode) lhs);
-
-    // TODO: it would be better to defer getting the path until after we check
-    // for a ResetMustCall annotation, because getting the path can be expensive.
-    // It might be possible to exploit the CFG structure to find the containing
-    // method (rather than using the path, as below), because if a method is being
-    // analyzed then it should be the root of the CFG (I think).
-    TreePath currentPath = typeFactory.getPath(node.getTree());
-    MethodTree enclosingMethod = TreePathUtil.enclosingMethod(currentPath);
-    if (enclosingMethod == null) {
-      // Assignments outside of methods must be in constructors or field initializers, which
-      // are always safe.
+    if (TreeUtils.isConstructor(enclosingMethod)) {
+      // Resetting a constructor doesn't make sense.
       return;
     }
     ExecutableElement enclosingElt = TreeUtils.elementFromDeclaration(enclosingMethod);

--- a/object-construction-checker/tests/socket/SocketContainer.java
+++ b/object-construction-checker/tests/socket/SocketContainer.java
@@ -1,0 +1,31 @@
+// A simple class that has a Socket as an owning field.
+// This test exists to check that we gracefully handle assignments 1)
+// in the constructor and 2) to null.
+
+import java.net.*;
+import java.io.*;
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("close")
+class SocketContainer {
+    @Owning Socket sock;
+
+    public SocketContainer(String host, int port) throws Exception {
+        // It's okay to assign to uninitialized owning fields in the constructor.
+        sock = new Socket(host, port);
+        // But it's not okay to do it twice!
+        // :: error: required.method.not.called
+        sock = new Socket(host, port);
+    }
+
+    @EnsuresCalledMethods(value="this.sock", methods="close")
+    public void close() throws IOException {
+        sock.close();
+        // It's okay to assign a field to null after its obligations have been fulfilled,
+        // without inducing a reset.
+        sock = null;
+    }
+}

--- a/object-construction-checker/tests/socket/SocketContainer.java
+++ b/object-construction-checker/tests/socket/SocketContainer.java
@@ -14,9 +14,12 @@ class SocketContainer {
     @Owning Socket sock;
 
     public SocketContainer(String host, int port) throws Exception {
-        // It's okay to assign to uninitialized owning fields in the constructor.
+        // It should be okay to assign to uninitialized owning fields in the constructor.
+        // But it isn't! Why? There's no guarantee that some subclass hasn't already run its own
+        // constructor and assigned sock, so permitting this assignment would be unsound.
+        // :: error: required.method.not.called
         sock = new Socket(host, port);
-        // But it's not okay to do it twice!
+        // It's definitely not okay to do it twice!
         // :: error: required.method.not.called
         sock = new Socket(host, port);
     }

--- a/object-construction-checker/tests/socket/SocketContainer.java
+++ b/object-construction-checker/tests/socket/SocketContainer.java
@@ -15,8 +15,7 @@ class SocketContainer {
 
     public SocketContainer(String host, int port) throws Exception {
         // It should be okay to assign to uninitialized owning fields in the constructor.
-        // But it isn't! Why? There's no guarantee that some subclass hasn't already run its own
-        // constructor and assigned sock, so permitting this assignment would be unsound.
+        // But it isn't! Why?
         // :: error: required.method.not.called
         sock = new Socket(host, port);
         // It's definitely not okay to do it twice!

--- a/object-construction-checker/tests/socket/SocketContainer2.java
+++ b/object-construction-checker/tests/socket/SocketContainer2.java
@@ -1,0 +1,26 @@
+// A simple class that has a Socket as an owning field.
+// This test exists to check that we gracefully handle assignments to it.
+
+import java.net.*;
+import java.io.*;
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("close")
+class SocketContainer2 {
+
+    @Owning Socket sock = new Socket();
+
+    public SocketContainer2(String host, int port) throws Exception {
+        // It's not okay to assign to a field with an initializer!
+        // :: error: required.method.not.called
+        sock = new Socket(host, port);
+    }
+
+    @EnsuresCalledMethods(value="this.sock", methods="close")
+    public void close() throws IOException {
+        sock.close();
+    }
+}

--- a/object-construction-checker/tests/socket/SocketContainer3.java
+++ b/object-construction-checker/tests/socket/SocketContainer3.java
@@ -1,0 +1,24 @@
+// A simple class that has a Socket as an owning field.
+// This test exists to check that we gracefully handle assignments.
+
+import java.net.*;
+import java.io.*;
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("close")
+class SocketContainer3 {
+    @Owning Socket sock = null;
+
+    public SocketContainer3(String host, int port) throws Exception {
+        // It's not okay to assign to a field with an initializer, unless that initializer is a null literal.
+        sock = new Socket(host, port);
+    }
+
+    @EnsuresCalledMethods(value="this.sock", methods="close")
+    public void close() throws IOException {
+        sock.close();
+    }
+}

--- a/object-construction-checker/tests/socket/SocketContainer3.java
+++ b/object-construction-checker/tests/socket/SocketContainer3.java
@@ -13,7 +13,10 @@ class SocketContainer3 {
     @Owning Socket sock = null;
 
     public SocketContainer3(String host, int port) throws Exception {
-        // It's not okay to assign to a field with an initializer, unless that initializer is a null literal.
+        // Even if the field appears to always be initialized to null,
+        // a subclass constructor could have already run - making this
+        // assignment dangerous!.
+        // :: error: required.method.not.called
         sock = new Socket(host, port);
     }
 

--- a/object-construction-checker/tests/socket/SocketContainer3.java
+++ b/object-construction-checker/tests/socket/SocketContainer3.java
@@ -14,8 +14,7 @@ class SocketContainer3 {
 
     public SocketContainer3(String host, int port) throws Exception {
         // Even if the field appears to always be initialized to null,
-        // a subclass constructor could have already run - making this
-        // assignment dangerous!.
+        // so why isn't this safe?
         // :: error: required.method.not.called
         sock = new Socket(host, port);
     }


### PR DESCRIPTION
This PR covers several false positive causes in Zookeeper, all of which are related to `@ResetMustCall`:
* Reset must call required on constructor (2)
* Reassignment of owning field to null required reset must call (2)
* Required method not called on rhs of initializer of owning field (2)

It leaves in place some "expected" errors in the new tests that I don't think we actually need. These are errors about "re-assignments" to fields that occur in the constructor. I think such a "re-"assignment is safe if:
1. the field is defined in the class (i.e. the field isn't defined in a superclass)
2. the initializer is either not present or a `null` literal
3. the constructor doesn't dispatch to another constructor that might set the field (i.e. there is no `this(...)` call at the start of the constructor - calls to `super()` are okay because of 1.)
4. no other methods have yet been called in the constructor (since they might also assign the field - although we could probably weaken this to "no reset must call methods have been called" and be okay)

I haven't implemented these rules yet, but if you think they're sound then I could do so (at least the 2 false positives above in the "reset must call on constructor" category will remain if I don't).