### PR TITLE
make reset must call repeatable

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -1,6 +1,10 @@
 package org.checkerframework.checker.mustcall;
 
 import com.sun.source.util.TreePath;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.mustcall.qual.ResetMustCall;
@@ -39,8 +43,8 @@ public class MustCallTransfer extends CFTransfer {
   public TransferResult<CFValue, CFStore> visitMethodInvocation(
       MethodInvocationNode n, TransferInput<CFValue, CFStore> in) {
     TransferResult<CFValue, CFStore> result = super.visitMethodInvocation(n, in);
-    JavaExpression targetExpr = getResetMustCallExpression(n, atypeFactory);
-    if (targetExpr != null) {
+    Set<JavaExpression> targetExprs = getResetMustCallExpressions(n, atypeFactory);
+    for (JavaExpression targetExpr : targetExprs) {
       AnnotationMirror defaultType =
           atypeFactory
               .getAnnotatedType(TypesUtils.getTypeElement(targetExpr.getType()))
@@ -63,26 +67,87 @@ public class MustCallTransfer extends CFTransfer {
   }
 
   /**
-   * If the given method invocation node is a ResetMustCall method, then gets the corresponding
-   * JavaExpression. If the expression is unparseable, this method uses the type factory's error
-   * reporting inferface to throw an error and returns null. Also return null if the given method is
-   * not a ResetMustCall method.
+   * If the given method invocation node is a ResetMustCall method, then gets the JavaExpressions
+   * corresponding to the targets. If any expression is unparseable, this method uses the type
+   * factory's error reporting inferface to throw an error and returns the empty set. Also return
+   * the empty set if the given method is not a ResetMustCall method.
    *
    * @param n a method invocation
    * @param atypeFactory the type factory to report errors and parse the expression string
-   * @return a JavaExpression representing the target, if the method is a ResetMustCall method and
-   *     the target is parseable; null otherwise.
+   * @return a list of JavaExpressions representing the targets, if the method is a ResetMustCall
+   *     method and the targets are parseable; the empty set otherwise.
    */
-  public static @Nullable JavaExpression getResetMustCallExpression(
+  public static Set<JavaExpression> getResetMustCallExpressions(
       MethodInvocationNode n, GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory) {
+    return getResetMustCallExpressions(n, atypeFactory, null);
+  }
+
+  /**
+   * If the given method invocation node is a ResetMustCall method, then gets the JavaExpressions
+   * corresponding to the targets. If any expression is unparseable, this method uses the type
+   * factory's error reporting inferface to throw an error and returns the empty set. Also return
+   * the empty set if the given method is not a ResetMustCall method.
+   *
+   * @param n a method invocation
+   * @param atypeFactory the type factory to report errors and parse the expression string
+   * @param currentPath the path to n, if it is already available, to avoid potentially-expensive
+   *     recomputation. If null, the path will be computed.
+   * @return a list of JavaExpressions representing the targets, if the method is a ResetMustCall
+   *     method and the targets are parseable; the empty set otherwise.
+   */
+  public static Set<JavaExpression> getResetMustCallExpressions(
+      MethodInvocationNode n,
+      GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory,
+      @Nullable TreePath currentPath) {
     AnnotationMirror resetMustCall =
         atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), ResetMustCall.class);
     if (resetMustCall == null) {
-      return null;
+      AnnotationMirror resetMustCallList =
+          atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), ResetMustCall.List.class);
+      if (resetMustCallList == null) {
+        return Collections.emptySet();
+      }
+      // Handle a set of reset must call annotations.
+      List<AnnotationMirror> resetMustCalls =
+          AnnotationUtils.getElementValueArray(
+              resetMustCallList, "value", AnnotationMirror.class, false);
+      Set<JavaExpression> results = new HashSet<>();
+      if (currentPath == null) {
+        currentPath = atypeFactory.getPath(n.getTree());
+      }
+      for (AnnotationMirror rmc : resetMustCalls) {
+        JavaExpression expr = getResetMustCallExpressionsImpl(rmc, n, atypeFactory, currentPath);
+        if (expr != null) {
+          results.add(expr);
+        }
+      }
+      return results;
     }
+    // Handle a single reset must call annotation.
+    if (currentPath == null) {
+      currentPath = atypeFactory.getPath(n.getTree());
+    }
+    JavaExpression expr =
+        getResetMustCallExpressionsImpl(resetMustCall, n, atypeFactory, currentPath);
+    return expr != null ? Collections.singleton(expr) : Collections.emptySet();
+  }
+
+  /**
+   * Implementation of parsing a single ResetMustCall annotation. See {@link
+   * #getResetMustCallExpressions(MethodInvocationNode, GenericAnnotatedTypeFactory)}.
+   *
+   * @param resetMustCall a reset must call annotation
+   * @param n the method invocation of a reset method
+   * @param atypeFactory the type factory
+   * @return the java expression representing the target, or null if the target is unparseable
+   */
+  private static @Nullable JavaExpression getResetMustCallExpressionsImpl(
+      AnnotationMirror resetMustCall,
+      MethodInvocationNode n,
+      GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory,
+      TreePath currentPath) {
     String targetStrWithoutAdaptation =
         AnnotationUtils.getElementValue(resetMustCall, "value", String.class, true);
-    TreePath currentPath = atypeFactory.getPath(n.getTree());
     JavaExpressionContext context =
         JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodUse(
             n, atypeFactory.getChecker());

--- a/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/ResetMustCall.java
+++ b/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/ResetMustCall.java
@@ -1,10 +1,12 @@
 package org.checkerframework.checker.mustcall.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.InheritedAnnotation;
 import org.checkerframework.framework.qual.JavaExpression;
 
 /**
@@ -23,10 +25,14 @@ import org.checkerframework.framework.qual.JavaExpression;
  *
  * <p>This annotation is trusted, not checked (though it can only add obligations, so is still
  * conservative).
+ *
+ * <p>This annotation is repeatable: a programmer may write more than one {@code ResetMustCall}
+ * annotation on a single method. If so, the annotations should have different targets.
  */
 @Target({ElementType.METHOD})
-@Inherited
+@InheritedAnnotation
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(ResetMustCall.List.class)
 public @interface ResetMustCall {
 
   /**
@@ -35,4 +41,23 @@ public @interface ResetMustCall {
    */
   @JavaExpression
   String value() default "this";
+
+  /**
+   * A wrapper annotation that makes the {@link ResetMustCall} annotation repeatable.
+   *
+   * <p>Programmers generally do not need to write this. It is created by Java when a programmer
+   * writes more than one {@link ResetMustCall} annotation at the same location.
+   */
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD})
+  @InheritedAnnotation
+  @interface List {
+    /**
+     * Return the repeatable annotations.
+     *
+     * @return the repeatable annotations
+     */
+    ResetMustCall[] value();
+  }
 }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
 import org.checkerframework.checker.calledmethods.qual.CalledMethods;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsBottom;
@@ -18,6 +19,7 @@ import org.checkerframework.checker.mustcall.MustCallAnnotatedTypeFactory;
 import org.checkerframework.checker.mustcall.MustCallChecker;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.mustcall.qual.MustCallChoice;
+import org.checkerframework.checker.mustcall.qual.ResetMustCall;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.MustCallInvokedChecker.LocalVarWithTree;
 import org.checkerframework.com.google.common.collect.ImmutableSet;
@@ -25,6 +27,7 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.expression.LocalVariable;
 import org.checkerframework.framework.flow.CFStore;
@@ -200,5 +203,19 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
         getTypeFactoryOfSubchecker(MustCallChecker.class);
     return mustCallAnnotatedTypeFactory.getDeclAnnotationNoAliases(elt, MustCallChoice.class)
         != null;
+  }
+
+  /**
+   * Returns true if the declaration of the method being invoked has one or more {@link
+   * ResetMustCall} annotations.
+   *
+   * @param node a method invocation node
+   * @return true iff there is one or more reset must call annotations on the declaration of the
+   *     invoked method
+   */
+  public boolean hasResetMustCall(MethodInvocationNode node) {
+    ExecutableElement decl = TreeUtils.elementFromUse(node.getTree());
+    return getDeclAnnotation(decl, ResetMustCall.class) != null
+        || getDeclAnnotation(decl, ResetMustCall.List.class) != null;
   }
 }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -121,8 +121,8 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
   }
 
   void handleResetMustCall(MethodInvocationNode n, TransferResult<CFValue, CFStore> result) {
-    JavaExpression targetExpr = MustCallTransfer.getResetMustCallExpression(n, atypeFactory);
-    if (targetExpr != null) {
+    Set<JavaExpression> targetExprs = MustCallTransfer.getResetMustCallExpressions(n, atypeFactory);
+    for (JavaExpression targetExpr : targetExprs) {
       AnnotationMirror defaultType = atypefactory.top;
       if (result.containsTwoStores()) {
         CFStore thenStore = result.getThenStore();

--- a/object-construction-checker/tests/mustcall/ResetMustCallIndirect.java
+++ b/object-construction-checker/tests/mustcall/ResetMustCallIndirect.java
@@ -41,7 +41,7 @@ class ResetMustCallIndirect {
     public static void reset_local3() {
         // :: error: required.method.not.called
         ResetMustCallIndirect r = new ResetMustCallIndirect();
-        // :: error: mustcall.not.parseable
+        // :: error: mustcall.not.parseable :: error: reset.not.owning
         ((ResetMustCallIndirect) r).reset();
     }
 

--- a/object-construction-checker/tests/mustcall/ResetMustCallRepeat.java
+++ b/object-construction-checker/tests/mustcall/ResetMustCallRepeat.java
@@ -1,0 +1,72 @@
+// A simple test that @ResetMustCall is repeatable and works as intended.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+
+@MustCall("a")
+class ResetMustCallRepeat {
+
+    @ResetMustCall("this")
+    @ResetMustCall("#1")
+    void reset(ResetMustCallRepeat r) { }
+
+    void a() { }
+
+    static @MustCall({}) ResetMustCallRepeat makeNoMC() {
+        return null;
+    }
+
+    static void test1() {
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs1 = makeNoMC();
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs2 = makeNoMC();
+        @MustCall({}) ResetMustCallRepeat a = rmcs2;
+        @MustCall({}) ResetMustCallRepeat a2 = rmcs2;
+        rmcs2.a();
+        rmcs1.reset(rmcs2);
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"reset"}) ResetMustCallRepeat b = rmcs1;
+        @CalledMethods({}) ResetMustCallRepeat c = rmcs1;
+        @CalledMethods({}) ResetMustCallRepeat d = rmcs2;
+        // :: error: assignment.type.incompatible
+        @CalledMethods({"a"}) ResetMustCallRepeat e = rmcs2;
+    }
+
+    static void test3() {
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs = new ResetMustCallRepeat();
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs2 = new ResetMustCallRepeat();
+        rmcs.a();
+        rmcs.reset(rmcs2);
+    }
+
+    static void test4() {
+        ResetMustCallRepeat rmcs = new ResetMustCallRepeat();
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs2 = new ResetMustCallRepeat();
+        rmcs.a();
+        rmcs.reset(rmcs2);
+        rmcs.a();
+    }
+
+    static void test5() {
+        // :: error: required.method.not.called
+        ResetMustCallRepeat rmcs = new ResetMustCallRepeat();
+        ResetMustCallRepeat rmcs2 = new ResetMustCallRepeat();
+        rmcs.a();
+        rmcs.reset(rmcs2);
+        rmcs2.a();
+    }
+
+    static void test6() {
+        ResetMustCallRepeat rmcs = new ResetMustCallRepeat();
+        ResetMustCallRepeat rmcs2 = new ResetMustCallRepeat();
+        rmcs.a();
+        rmcs.reset(rmcs2);
+        rmcs2.a();
+        rmcs.a();
+    }
+}

--- a/object-construction-checker/tests/socket/BindChannel.java
+++ b/object-construction-checker/tests/socket/BindChannel.java
@@ -17,7 +17,7 @@ class BindChannel {
             //
             // :: error: required.method.not.called
             ServerSocketChannel httpChannel = ServerSocketChannel.open();
-            // :: error: mustcall.not.parseable
+            // :: error: mustcall.not.parseable :: error: reset.not.owning
             httpChannel.socket().bind(addr);
         } catch (IOException io) {
 


### PR DESCRIPTION
This was a lot more invasive of a change than I'd expected, which is especially galling given that this will reduce the FP count by at most one on Zookeeper. Still, I think it's something we should have.

There is one visible behavior change: unparseable expressions that are the target of an RMC method are now also flagged as non-owning. I think that's fine, since we're issuing errors in those cases anyway. See e.g. the change in `BindChannel.java`.