### PR TITLE
handle reflection unsoundly via stub file

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallChecker.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallChecker.java
@@ -9,7 +9,13 @@ import org.checkerframework.framework.qual.StubFiles;
  * This typechecker ensures that {@link MustCall} annotations are consistent with one another. The
  * Object Construction Checker verifies that the given methods are actually called.
  */
-@StubFiles({"Socket.astub", "NotOwning.astub", "Stream.astub", "NoObligationStreams.astub"})
+@StubFiles({
+  "Socket.astub",
+  "NotOwning.astub",
+  "Stream.astub",
+  "NoObligationStreams.astub",
+  "Reflection.astub"
+})
 public class MustCallChecker extends BaseTypeChecker {
 
   /**

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Reflection.astub
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Reflection.astub
@@ -1,0 +1,16 @@
+// Contains assumptions about reflection. In particular, this
+// makes the results of reflection the default (i.e. bottom) type
+// in the Must Call type system. This choice is technically unsound:
+// if e.g. the java.net.Socket constructor is invoked via reflection,
+// then our checker will fail to track it. For usability, we found it
+// much more useful to ignore these warnings than to issue them.
+// If you wish to see warnings related to reflection, remove this stub file
+// when running the checker.
+
+package java.lang.reflect;
+
+import org.checkerframework.checker.mustcall.qual.MustCall;
+
+class Constructor<T> {
+    @MustCall({}) T newInstance(Object... initArgs);
+}

--- a/must-call-checker/tests/mustcall/ClassForNameInit.java
+++ b/must-call-checker/tests/mustcall/ClassForNameInit.java
@@ -18,7 +18,6 @@ class ClassForNameInit {
     public static Object objectFactory() throws Exception {
         Class<?> objClass = Class.forName("java.lang.Object");
         Object obj = objClass.getConstructor().newInstance();
-        // :: error: return.type.incompatible
         return (Object) obj;
     }
 

--- a/must-call-checker/tests/mustcall/ClassForNameInit.java
+++ b/must-call-checker/tests/mustcall/ClassForNameInit.java
@@ -3,6 +3,7 @@
 // persist even with that flag, which also imposes about a 50% perf overhead. So these are now expected warnings.
 
 import java.io.*;
+import java.lang.reflect.Constructor;
 
 class ClassForNameInit {
 
@@ -19,5 +20,19 @@ class ClassForNameInit {
         Object obj = objClass.getConstructor().newInstance();
         // :: error: return.type.incompatible
         return (Object) obj;
+    }
+
+    private static Object getAuditLogger(String auditLoggerClass) {
+        if (auditLoggerClass == null) {
+            auditLoggerClass = Object.class.getName();
+        }
+        try {
+            Constructor<?> clientCxnConstructor = Class.forName(auditLoggerClass)
+                    .getDeclaredConstructor();
+            Object auditLogger = (Object) clientCxnConstructor.newInstance();
+            return auditLogger;
+        } catch (Exception e) {
+            throw new RuntimeException("Couldn't instantiate " + auditLoggerClass, e);
+        }
     }
 }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -25,7 +25,8 @@ import org.checkerframework.framework.source.SuppressWarningsPrefix;
   "NotOwning.astub",
   "Stream.astub",
   "NoObligationStreams.astub",
-  "IOUtils.astub"
+  "IOUtils.astub",
+  "Reflection.astub"
 })
 @SupportedOptions({CHECK_MUST_CALL, COUNT_MUST_CALL})
 public class ObjectConstructionChecker extends CalledMethodsChecker {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/Reflection.astub
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/Reflection.astub
@@ -1,0 +1,1 @@
+../../../../../../../../must-call-checker/src/main/java/org/checkerframework/checker/mustcall/Reflection.astub


### PR DESCRIPTION
as we discussed today, this is definitely the right choice from a usability standpoint, even though it is technically unsound

should be easy to turn off this kind of handling by removing the stub, if we wanted