### PR TITLE
use compiler messaging interface to print counts instead of printf

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.objectconstruction;
 
+import static javax.tools.Diagnostic.Kind.NOTE;
 import static org.checkerframework.checker.mustcall.MustCallChecker.NO_ACCUMULATION_FRAMES;
 import static org.checkerframework.checker.objectconstruction.ObjectConstructionChecker.CHECK_MUST_CALL;
 import static org.checkerframework.checker.objectconstruction.ObjectConstructionChecker.COUNT_MUST_CALL;
@@ -106,8 +107,9 @@ public class ObjectConstructionChecker extends CalledMethodsChecker {
   @Override
   public void typeProcessingOver() {
     if (hasOption(COUNT_MUST_CALL)) {
-      System.out.printf("Found %d must call obligation(s).%n", numMustCall);
-      System.out.printf(
+      message(NOTE, "Found %d must call obligation(s).%n", numMustCall);
+      message(
+          NOTE,
           "Found %d must call obligation(s) that were handled correctly.%n",
           numMustCall - numMustCallFailed);
     }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -110,7 +110,7 @@ public class ObjectConstructionChecker extends CalledMethodsChecker {
       message(NOTE, "Found %d must call obligation(s).%n", numMustCall);
       message(
           NOTE,
-          "Found %d must call obligation(s) that were handled correctly.%n",
+          "Successfully verified %d must call obligation(s).%n",
           numMustCall - numMustCallFailed);
     }
     super.typeProcessingOver();


### PR DESCRIPTION
this is slightly an anti-pattern, since it doesn't use the localizable interface, but this is the only API we have that doesn't require a source location at which to print

running the tests also no longer prints the counts directly, since these messages are below the logging level used by the testing framework (because we use `-Anowarn` in our test runs)