### PR TITLE
adapt to improved precision in CF CFG

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -1138,8 +1138,11 @@ class MustCallInvokedChecker {
    * in the JVM, like OutOfMemoryErrors or ClassCircularityErrors.
    */
   private static boolean isIgnoredExceptionType(@FullyQualifiedName Name exceptionClassName) {
-    // any method call has a CFG edge for Throwable to represent run-time misbehavior. Ignore it.
+    // any method call has a CFG edge for Throwable/RuntimeException/Error to represent run-time
+    // misbehavior. Ignore it.
     return exceptionClassName.contentEquals(Throwable.class.getCanonicalName())
+        || exceptionClassName.contentEquals(RuntimeException.class.getCanonicalName())
+        || exceptionClassName.contentEquals(Error.class.getCanonicalName())
         // use the Nullness Checker to prove this won't happen
         || exceptionClassName.contentEquals(NullPointerException.class.getCanonicalName())
         // these errors can't be predicted statically, so we'll ignore them and assume they won't

--- a/object-construction-checker/tests/mustcall/ACExceptionalExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACExceptionalExitPointTest.java
@@ -23,16 +23,16 @@ class ACExceptionalExitPointTest {
         return f;
     }
 
-    void exceptionalExitWrong() {
+    void exceptionalExitWrong() throws Exception {
         // :: error: required.method.not.called
         Foo fw = makeFoo();
-        throw new RuntimeException();
+        throw new Exception();
     }
 
-    void exceptionalExitCorrect() {
+    void exceptionalExitCorrect() throws Exception {
         Foo fw = new Foo();
         fw.a();
-        throw new RuntimeException();
+        throw new Exception();
     }
 
 }


### PR DESCRIPTION
when I reran on Zookeeper, there were a bunch of extra false positives because of the improved precision in the CFG that we merged upstream earlier today, because `RuntimeException` and `Error` weren't on the list of exceptions that are permitted.