### PR TITLE
enforce requirements on constructor return types

### DIFF
--- a/object-construction-checker/tests/mustcall/ManualMustCallEmptyOnConstructor.java
+++ b/object-construction-checker/tests/mustcall/ManualMustCallEmptyOnConstructor.java
@@ -1,0 +1,27 @@
+// test for https://github.com/kelloggm/object-construction-checker/issues/326
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.common.returnsreceiver.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+import java.io.InputStream;
+
+class ManualMustCallEmptyOnConstructor {
+
+    // Test that writing @MustCall({}) on a constructor results in an error
+    @MustCall("a")
+    static class Foo {
+        final @Owning InputStream is;
+
+        // :: error: inconsistent.constructor.type
+        @MustCall({}) Foo(@Owning InputStream is) {
+            this.is = is;
+        }
+
+        @EnsuresCalledMethods(value="this.is", methods="close")
+        void a() throws Exception {
+            is.close();
+        }
+    }
+}

--- a/object-construction-checker/tests/socket/ZookeeperReport3.java
+++ b/object-construction-checker/tests/socket/ZookeeperReport3.java
@@ -62,6 +62,7 @@ class ZookeeperReport3 {
 
     class UnifiedServerSocket extends ServerSocket {
         // A human has to verify that this constructor actually does produce an unconnected socket.
+        @SuppressWarnings("inconsistent.constructor.type")
         public @MustCall({}) UnifiedServerSocket(boolean b) throws IOException {
             super();
         }


### PR DESCRIPTION
fixes #326 

I had expected the CF to just handle this (via the Must Call Checker), so I was surprised when the test I wrote didn't fail. The reason was that I had disabled the relevant checking in BaseTypeVisitor for the Must Call Checker, because it was overly conservative - it assumed that every constructor return needed to be top! That's clearly inconsistent with Must Call (or any bottom-default typechecker, for that matter).

Actually, the constructor return just needs to be a super type of the declared lower bound for the class. This PR implements that check for Must Call.

IMO this change should probably be upstreamed into the CF's `BaseTypeVisitor`, probably after 25 Feb