### PR TITLE
Verify mcc

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTypeValidator.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTypeValidator.java
@@ -1,0 +1,33 @@
+package org.checkerframework.checker.mustcall;
+
+import com.sun.source.tree.Tree;
+import javax.lang.model.element.Element;
+import org.checkerframework.checker.mustcall.qual.MustCallChoice;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.common.basetype.BaseTypeValidator;
+import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.TreeUtils;
+
+/**
+ * This type validator is identical to BaseTypeValidator, except that it always permits the use of
+ * {@link org.checkerframework.checker.mustcall.qual.MustCallChoice} annotations on type uses,
+ * because these will be validated by the Object Construction Checker's -AcheckMustCall algorithm.
+ */
+public class MustCallTypeValidator extends BaseTypeValidator {
+  public MustCallTypeValidator(
+      BaseTypeChecker checker, BaseTypeVisitor<?> visitor, AnnotatedTypeFactory atypeFactory) {
+    super(checker, visitor, atypeFactory);
+  }
+
+  @Override
+  protected void reportInvalidAnnotationsOnUse(AnnotatedTypeMirror type, Tree p) {
+    Element elt = TreeUtils.elementFromTree(p);
+    if (AnnotationUtils.containsSameByClass(elt.getAnnotationMirrors(), MustCallChoice.class)) {
+      return;
+    }
+    super.reportInvalidAnnotationsOnUse(type, p);
+  }
+}

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.objectconstruction.qual.NotOwning;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.common.basetype.TypeValidator;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.javacutil.ElementUtils;
@@ -177,5 +178,10 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
   @Override
   public Void visitAnnotation(AnnotationTree node, Void p) {
     return null;
+  }
+
+  @Override
+  protected TypeValidator createTypeValidator() {
+    return new MustCallTypeValidator(checker, this, atypeFactory);
   }
 }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -203,27 +203,22 @@ class MustCallInvokedChecker {
 
   /**
    * If node is an invocation of a this or super constructor that has a MCC return type and an MCC
-   * parameter, check if any variable in defs is an MCC parameter being passed to the other
-   * constructor. If so, remove it from defs.
+   * parameter, check if any variable in defs is being passed to the other constructor. If so,
+   * remove it from defs.
    *
    * @param defs current defs
-   * @param node a method or constructor invocation
+   * @param node a super or this constructor invocation
    */
   private void handleThisOrSuperConstructorMustCallChoice(
       Set<ImmutableSet<LocalVarWithTree>> defs, Node node) {
-    if (node instanceof ObjectCreationNode || node instanceof MethodInvocationNode) {
-      Node mccParam = getVarOrTempVarPassedAsMustCallChoiceParam(node);
-      // if the MCC param is also a MCC def in the def set, then remove it -
-      // its obligation has been fulfilled by being passed on to another MCC method/constructor
-      if (mccParam instanceof LocalVariableNode
-          && isVarInDefs(defs, (LocalVariableNode) mccParam)) {
-        LocalVarWithTree lvt = getAssignmentTreeOfVar(defs, (LocalVariableNode) mccParam);
-        if (lvt.isMustCallChoice) {
-          ImmutableSet<LocalVarWithTree> setContainingMustCallChoiceParamLocal =
-              getSetContainingAssignmentTreeOfVar(defs, (LocalVariableNode) mccParam);
-          defs.remove(setContainingMustCallChoiceParamLocal);
-        }
-      }
+    Node mccParam = getVarOrTempVarPassedAsMustCallChoiceParam(node);
+    // If the MCC param is also in the def set, then remove it -
+    // its obligation has been fulfilled by being passed on to the MCC constructor (because we must
+    // be in a constructor body if we've encountered a this/super constructor call).
+    if (mccParam instanceof LocalVariableNode && isVarInDefs(defs, (LocalVariableNode) mccParam)) {
+      ImmutableSet<LocalVarWithTree> setContainingMustCallChoiceParamLocal =
+          getSetContainingAssignmentTreeOfVar(defs, (LocalVariableNode) mccParam);
+      defs.remove(setContainingMustCallChoiceParamLocal);
     }
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -1025,8 +1025,7 @@ class MustCallInvokedChecker {
             || (typeFactory.hasMustCall(param)
                 && paramElement.getAnnotation(Owning.class) != null)) {
           Set<LocalVarWithTree> setOfLocals = new LinkedHashSet<>();
-          setOfLocals.add(
-              new LocalVarWithTree(new LocalVariable(paramElement), param, isMustCallChoice));
+          setOfLocals.add(new LocalVarWithTree(new LocalVariable(paramElement), param));
           init.add(ImmutableSet.copyOf(setOfLocals));
           // Increment numMustCall for each @Owning parameter tracked by the enclosing method
           incrementNumMustCall(param);
@@ -1255,17 +1254,9 @@ class MustCallInvokedChecker {
     public final LocalVariable localVar;
     public final Tree tree;
 
-    /** true if this is a must-call-choice parameter, which gives it special rules */
-    public final boolean isMustCallChoice;
-
     public LocalVarWithTree(LocalVariable localVarNode, Tree tree) {
-      this(localVarNode, tree, false);
-    }
-
-    public LocalVarWithTree(LocalVariable localVarNode, Tree tree, boolean isMustCallChoice) {
       this.localVar = localVarNode;
       this.tree = tree;
-      this.isMustCallChoice = isMustCallChoice;
     }
 
     @Override

--- a/object-construction-checker/tests/mustcall/MustCallChoiceImplWrong1.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoiceImplWrong1.java
@@ -1,18 +1,19 @@
 // A simple test that the extra obligations that MustCallChoice imposes are
-// respected.
+// respected. This version gets it wrong by not assigning the MCC param
+// to a field.
 
 import org.checkerframework.checker.mustcall.qual.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.objectconstruction.qual.*;
 import java.io.*;
 
-public class MustCallChoiceImpl implements Closeable {
+public class MustCallChoiceImplWrong1 implements Closeable {
 
     final @Owning Closeable foo;
 
-    // I got this error here: (type.invalid.annotations.on.use)
-    public @MustCallChoice MustCallChoiceImpl(@MustCallChoice Closeable foo) {
-        this.foo = foo;
+    // :: error: required.method.not.called
+    public @MustCallChoice MustCallChoiceImplWrong1(@MustCallChoice Closeable foo) {
+        this.foo = null;
     }
 
     @Override

--- a/object-construction-checker/tests/mustcall/MustCallChoiceImplWrong2.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoiceImplWrong2.java
@@ -1,0 +1,23 @@
+// A simple test that the extra obligations that MustCallChoice imposes are
+// respected. This version gets it wrong by assigning the MCC param to a non-owning
+// field.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+public class MustCallChoiceImplWrong2 implements Closeable {
+
+    final /*@Owning*/ Closeable foo;
+
+    // :: error: required.method.not.called
+    public @MustCallChoice MustCallChoiceImplWrong2(@MustCallChoice Closeable foo) {
+        this.foo = foo;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthrough.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthrough.java
@@ -1,0 +1,13 @@
+// A test that a class can extend another class with an MCC constructor,
+// and have its own constructor be MCC as well.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthrough extends FilterInputStream {
+    @MustCallChoice MustCallChoicePassthrough(@MustCallChoice InputStream is) {
+        super(is);
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughChain.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughChain.java
@@ -1,0 +1,53 @@
+// This test checks that a chain of several MCC methods can be verified, and that messing up the chain
+// leads to errors.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughChain {
+
+    static @MustCallChoice InputStream withMCC(@MustCallChoice InputStream is) {
+        return is;
+    }
+
+    static @MustCallChoice InputStream chain1(@MustCallChoice InputStream is) {
+        return withMCC(is);
+    }
+
+    static @MustCallChoice InputStream chain2(@MustCallChoice InputStream is) {
+        InputStream s = withMCC(is);
+        return s;
+    }
+
+    static @MustCallChoice InputStream chain3(@MustCallChoice InputStream is) {
+        return withMCC(chain1(is));
+    }
+
+    static @MustCallChoice InputStream chain4(@MustCallChoice InputStream is) {
+        return withMCC(chain1(chain3(is)));
+    }
+
+    static @MustCallChoice InputStream chain5(@MustCallChoice InputStream is) {
+        InputStream s = withMCC(chain1(is));
+        return s;
+    }
+
+    // :: error: required.method.not.called
+    static @MustCallChoice InputStream chain_bad1(@MustCallChoice InputStream is) {
+        InputStream s = withMCC(chain1(is));
+        return null;
+    }
+
+    // :: error: required.method.not.called
+    static @MustCallChoice InputStream chain_bad2(@MustCallChoice InputStream is) {
+        withMCC(chain1(is));
+        return null;
+    }
+
+    // :: error: required.method.not.called
+    static @MustCallChoice InputStream chain_bad3(@MustCallChoice InputStream is, boolean b) {
+        return b ? null : withMCC(chain1(is));
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughLocal.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughLocal.java
@@ -1,0 +1,23 @@
+// A test that passing a local to an MCC super constructor is allowed.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughLocal extends FilterInputStream {
+    MustCallChoicePassthroughLocal(File f) throws Exception {
+        // This is safe - this MCC constructor of FilterInputStream means that the result of this
+        // constructor - i.e. the caller - is taking ownership of this newly-created output stream.
+        super(new FileInputStream(f));
+    }
+
+    static void test(File f) throws Exception {
+        // :: error: required.method.not.called
+        new MustCallChoicePassthroughLocal(f);
+    }
+
+    static void test_ok(File f) throws Exception {
+        new MustCallChoicePassthroughLocal(f).close();
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughThis.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughThis.java
@@ -1,0 +1,16 @@
+// A test that a class can have multiple MCC constructors.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughThis extends FilterInputStream {
+    @MustCallChoice MustCallChoicePassthroughThis(@MustCallChoice InputStream is) {
+        super(is);
+    }
+
+    @MustCallChoice MustCallChoicePassthroughThis(@MustCallChoice InputStream is, int x) {
+        this(is);
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong1.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong1.java
@@ -1,0 +1,15 @@
+// A test that a class can extend another class with an MCC constructor,
+// and have its own constructor be MCC as well.
+// This version just throws away the input rather than passing it to the super constructor.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughWrong1 extends FilterInputStream {
+    // :: error: required.method.not.called
+    @MustCallChoice MustCallChoicePassthroughWrong1(@MustCallChoice InputStream is) {
+        super(null);
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong2.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong2.java
@@ -1,6 +1,9 @@
 // A test that a class can extend another class with an MCC constructor,
 // and have its own constructor be MCC as well.
 // This version passes the MCC param to another method instead of the passthrough constructor.
+// This is actually okay - the stream does get closed, if it needs to be closed - though the
+// MCC annotation on the return type is super misleading and will lead to FPs. It would be better
+// to annotate code like this with @Owning on the constructor.
 
 import org.checkerframework.checker.mustcall.qual.*;
 import org.checkerframework.checker.calledmethods.qual.*;
@@ -8,7 +11,6 @@ import org.checkerframework.checker.objectconstruction.qual.*;
 import java.io.*;
 
 class MustCallChoicePassthroughWrong2 extends FilterInputStream {
-    // :: error: ?
     @MustCallChoice MustCallChoicePassthroughWrong2(@MustCallChoice InputStream is) throws Exception {
         super(null);
         closeIS(is);

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong2.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong2.java
@@ -1,0 +1,20 @@
+// A test that a class can extend another class with an MCC constructor,
+// and have its own constructor be MCC as well.
+// This version passes the MCC param to another method instead of the passthrough constructor.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughWrong2 extends FilterInputStream {
+    // :: error: ?
+    @MustCallChoice MustCallChoicePassthroughWrong2(@MustCallChoice InputStream is) throws Exception {
+        super(null);
+        closeIS(is);
+    }
+
+    void closeIS(@Owning InputStream is) throws Exception {
+        is.close();
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong3.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong3.java
@@ -1,0 +1,29 @@
+// This is a test for what happens when there's a missing MCC return type.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughWrong3 {
+    // Both of these verify - it's okay to leave off the MCC param, because the return type is
+    // owning - but the first one leads to imprecision at call sites.
+    static InputStream missingMCC(@MustCallChoice InputStream is) {
+        return is;
+    }
+
+    static @MustCallChoice InputStream withMCC(@MustCallChoice InputStream is) {
+        return is;
+    }
+
+    // :: error: required.method.not.called
+    void use_bad(@Owning InputStream is) throws Exception {
+        InputStream is2 = missingMCC(is);
+        is2.close();
+    }
+
+    void use_good(@Owning InputStream is) throws Exception {
+        InputStream is2 = withMCC(is);
+        is2.close();
+    }
+}

--- a/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong4.java
+++ b/object-construction-checker/tests/mustcall/MustCallChoicePassthroughWrong4.java
@@ -1,0 +1,17 @@
+// A test that a class can extend another class with an MCC constructor,
+// and have its own constructor be MCC as well.
+// This version just closes the MCC parameter, which isn't wrong so much as weird but I wanted a test for it.
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import java.io.*;
+
+class MustCallChoicePassthroughWrong4 extends FilterInputStream {
+    // I mean I guess this return type is technically okay - it's too conservative (@Owning on the
+    // param would be better) but I see no reason not to verify it.
+    @MustCallChoice MustCallChoicePassthroughWrong4(@MustCallChoice InputStream is) throws Exception {
+        super(null);
+        is.close();
+    }
+}


### PR DESCRIPTION
This was...much easier than I had expected. I was able to re-use the machinery we built for owning fields, for the most part - once an MCC thing is assigned to an owning field, we're okay since our rules for those are sound.

There are basically two changes to MCIC:
* an `@MustCallChoice` parameter is now owning in its own method. This means that the usual ways to get rid of an obligation are allowed: you can close it, pass it to another owning method, assign it to an owning field, whatever
* there's an extra way to get rid of MCC obligations: you can pass it to another MCC constructor

I also had to modify the Must Call Checker so that it doesn't complain about poly annotations on types that are lowerbounded by `@MustCall("close")` (or similar), when the actual annotation is MCC. I think this is sound - the correctness of the MCC anno is checked by the MCIC, and these annotations still have to obey the usual rules for polymorphic annos other than that one.

There are a bunch of tests because I had to convince myself it was this easy lol