### PR TITLE
fix RMC soundness bug

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -61,19 +61,38 @@ public class MustCallTransfer extends CFTransfer {
 
         if (result.containsTwoStores()) {
           CFStore thenStore = result.getThenStore();
-          thenStore.clearValue(targetExpr);
-          thenStore.insertValue(targetExpr, defaultType);
+          lubWithStoreValue(thenStore, targetExpr, defaultType);
+
           CFStore elseStore = result.getElseStore();
-          elseStore.clearValue(targetExpr);
-          elseStore.insertValue(targetExpr, defaultType);
+          lubWithStoreValue(elseStore, targetExpr, defaultType);
         } else {
           CFStore store = result.getRegularStore();
-          store.clearValue(targetExpr);
-          store.insertValue(targetExpr, defaultType);
+          lubWithStoreValue(store, targetExpr, defaultType);
         }
       }
     }
     return result;
+  }
+
+  /**
+   * Takes the LUB of the current value in the store for expr, if it exists, and defaultType.
+   * Inserts the result into the store as the new value for expr.
+   *
+   * @param store a CFStore
+   * @param expr an expression that might be in the store
+   * @param defaultType the default type of the expression's static type
+   */
+  private void lubWithStoreValue(CFStore store, JavaExpression expr, AnnotationMirror defaultType) {
+    CFValue value = store.getValue(expr);
+    CFValue defaultTypeAsValue = analysis.createSingleAnnotationValue(defaultType, expr.getType());
+    CFValue newValue;
+    if (value == null) {
+      newValue = defaultTypeAsValue;
+    } else {
+      newValue = value.leastUpperBound(defaultTypeAsValue);
+    }
+    store.clearValue(expr);
+    store.insertValue(expr, newValue);
   }
 
   @Override

--- a/object-construction-checker/tests/socket/BindChannel.java
+++ b/object-construction-checker/tests/socket/BindChannel.java
@@ -29,8 +29,8 @@ class BindChannel {
 
     static void test_lv(InetSocketAddress addr, boolean b) {
         try {
-            // :: error: required.method.not.called
             ServerSocketChannel httpChannel = ServerSocketChannel.open();
+            // :: error: required.method.not.called
             ServerSocket httpSock = httpChannel.socket();
             httpSock.bind(addr);
         } catch (IOException io) {

--- a/object-construction-checker/tests/socket/RMCInSubtype.java
+++ b/object-construction-checker/tests/socket/RMCInSubtype.java
@@ -1,0 +1,25 @@
+// A test for a bad interaction between RMC and subtyping
+// that could happen if RMC was unsound.
+
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+class RMCInSubtype {
+    static class Foo {
+
+        @ResetMustCall("this")
+        void resetFoo() { }
+    }
+
+    @MustCall("a")
+    static class Bar extends Foo {
+        void a() { }
+    }
+
+    static void test() {
+        // :: error: required.method.not.called
+        @MustCall("a") Foo f = new Bar();
+        f.resetFoo();
+    }
+}

--- a/object-construction-checker/tests/socket/UnconnectedSocketAlias.java
+++ b/object-construction-checker/tests/socket/UnconnectedSocketAlias.java
@@ -1,0 +1,14 @@
+// A test case for an interaction between RMC and aliasing that could
+// lead to a soundness bug if handled wrong.
+
+import java.net.*;
+
+class UnconnectedSocketAlias {
+    void test(SocketAddress sa) throws Exception {
+        // :: error: required.method.not.called
+        Socket s = new Socket();
+        Socket t = s;
+        t.close();
+        s.connect(sa);
+    }
+}


### PR DESCRIPTION
This did change where one error was issued in `BindChannel.java`, which seems to be the test case that changes the most. I think that's fine. The reason is that there's a two-alias set in defs before `bind` is called containing both locals, but after there's only the one-alias set containing the second local (so the error is issued at the second local instead of the first).

I believe that this aligns the implementation with what you were describing for the paper, for the most part - there's still the split between the MCC and MCIC, but that's probably okay.

I did keep the owning logic in place, so reset.not.owning errors do still get issued. The basic premise of the owning logic is that there has to be something which takes ownership of the result. I think we only track must-alias for things in the def set, but if that's not the case this might still be unsound.