### PR TITLE
make countMustCall only count java* types

### DIFF
--- a/object-construction-checker/tests/counter/CounterTest.java
+++ b/object-construction-checker/tests/counter/CounterTest.java
@@ -91,4 +91,11 @@ class CounterTest {
         }
     }
 
+    @MustCall("a") class Foo { }
+
+    // not counted
+    void test_non_java_star() {
+        // :: error: required.method.not.called
+        new Foo();
+    }
 }


### PR DESCRIPTION
I also removed the cache of things that we've already counted, because with it there I couldn't get the numbers on the Counter Test to be correct.