### PR TITLE
don't count warnings about non-JDK classes when computing the number of failed MCs

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -107,7 +107,11 @@ public class ObjectConstructionChecker extends CalledMethodsChecker {
   @Override
   public void reportError(Object source, @CompilerMessageKey String messageKey, Object... args) {
     if (messageKey.equals("required.method.not.called")) {
-      numMustCallFailed++;
+      // This looks crazy but it's safe because of the warning key.
+      String qualifiedTypeName = (String) args[1];
+      if (qualifiedTypeName.startsWith("java")) {
+        numMustCallFailed++;
+      }
     }
     super.reportError(source, messageKey, args);
   }

--- a/object-construction-checker/tests/counter/CounterTest.java
+++ b/object-construction-checker/tests/counter/CounterTest.java
@@ -91,11 +91,16 @@ class CounterTest {
         }
     }
 
-    @MustCall("a") class Foo { }
+    @MustCall("a") class Foo { void a() { } }
 
     // not counted
-    void test_non_java_star() {
+    void test_non_java_star_bad() {
         // :: error: required.method.not.called
         new Foo();
+    }
+
+    // not counted either
+    void test_non_java_star_ok() {
+        new Foo().a();
     }
 }


### PR DESCRIPTION
Narges noticed that my recent PR #336 didn't also update the computation of the `numFailedMustCall` field, so the results for that were garbage. This should fix it.