### PR TITLE
Adapt to Checker Framework changes

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -296,7 +296,7 @@ class MustCallInvokedChecker {
               AnnotationUtils.getElementValue(enclosingResetMustCall, "value", String.class, true);
           JavaExpressionContext enclosingContext =
               JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodDeclaration(
-                  enclosingMethod, currentPath, checker);
+                  enclosingMethod, checker);
           String enclosingTargetStr =
               MustCallTransfer.standardizeAndViewpointAdapt(
                   enclosingTargetStrWithoutAdaptation, currentPath, enclosingContext);
@@ -773,7 +773,7 @@ class MustCallInvokedChecker {
     }
     JavaExpressionContext context =
         JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodDeclaration(
-            enclosingMethod, currentPath, checker);
+            enclosingMethod, checker);
     String checked = "";
     for (String targetStrWithoutAdaptation : targetStrsWithoutAdaptation) {
       String targetStr =


### PR DESCRIPTION
This is necessary in order to use the latest Checker Framework.
Once this is merged, then you must do
```cd $CHECKERFRAMEWORK && ./gradlew publishToMavenLocal```
before compiling this reporitory.