### PR TITLE
Change `@Target` annotation on MustCallAlias

### DIFF
--- a/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
+++ b/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
@@ -35,5 +35,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.CONSTRUCTOR, ElementType.METHOD})
+// In Java 11, this can be:
+// @Target({ElementType.PARAMETER, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.PARAMETER, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE_USE})
 public @interface MustCallAlias {}


### PR DESCRIPTION
This is necessary for use with JDK 8.  (I don't know why.)

I have confirmed via testing that this works on JDK 8 whereas without the patch it does not.

After this is merged, Manu will need to make another release.