### PR TITLE
Remove unnecessary deps

### DIFF
--- a/object-construction-checker/build.gradle
+++ b/object-construction-checker/build.gradle
@@ -24,13 +24,6 @@ dependencies {
     implementation project(":must-call-qual")
     implementation project(":must-call-checker")
 
-    // For the @CalledMethodsPredicate evaluation
-    implementation "org.springframework:spring-expression:5.3.2"
-
-    // For subtyping between @CalledMethodsPredicate annotations
-    implementation 'org.sosy-lab:java-smt:3.2.0'
-    implementation 'com.github.javaparser:javaparser-core:3.15.11'
-
     // Use JUnit test framework
     testImplementation "junit:junit:4.13.1"
 


### PR DESCRIPTION
We don't need these dependencies anymore as the functionality is implemented within the Checker Framework.