### PR TITLE
Explain false positives due to implicit vs explicit bounds

### DIFF
--- a/must-call-checker/tests/mustcall/PlumeUtilRequiredAnnotations.java
+++ b/must-call-checker/tests/mustcall/PlumeUtilRequiredAnnotations.java
@@ -1,0 +1,50 @@
+// This is a test case that shows off some places in plume-util where
+// annotations were required, even though we'd have preferred the defaulting
+// rules to result in those annotations being the defaults.
+// See the discussion on https://github.com/kelloggm/object-construction-checker/pull/363
+// and https://github.com/plume-lib/plume-util/pull/126 for more details, especially
+// on why changing the default isn't feasible.
+
+import java.util.*;
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class PlumeUtilRequiredAnnotations {
+    // In the real version of this code, there is only one type parameter.
+    // T is the unannotated version of the parameter - i.e., what it was before
+    // we first ran the Must Call Checker. S is the annotated version. Adding the
+    // annotation itself is immaterial - what's important is that the bound
+    // must be explicit rather than implicit (see that the eqR field never issue errors,
+    // just like the eqS fields).
+    class MultiRandSelector<T, S extends @Nullable @MustCall Object, R extends Object> {
+        // :: error: type.argument.type.incompatible
+        private Partitioner<T, T> eqT;
+        private Partitioner<S, S> eqS;
+        private Partitioner<R, R> eqR;
+
+        // Adding annotations to the definition of Partitioner doesn't fix this problem:
+        // :: error: type.argument.type.incompatible
+        private Partitioner2<T, T> eqT2;
+        private Partitioner2<S, S> eqS2;
+        private Partitioner2<R, R> eqR2;
+
+        // But removing the explicit bounds on Partitioner does (not feasible in this case, though, because
+        // of the @Nullable annotations):
+        private Partitioner3<T, T> eqT3;
+        private Partitioner3<S, S> eqS3;
+        private Partitioner3<R, R> eqR3;
+    }
+
+    interface Partitioner<ELEMENT extends @Nullable Object, CLASS extends @Nullable Object> {
+        CLASS assignToBucket(ELEMENT obj);
+    }
+
+    interface Partitioner2<ELEMENT extends @Nullable @MustCall Object, CLASS extends @Nullable @MustCall Object> {
+        CLASS assignToBucket(ELEMENT obj);
+    }
+
+    interface Partitioner3<ELEMENT, CLASS> {
+        CLASS assignToBucket(ELEMENT obj);
+    }
+}

--- a/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCall.java
+++ b/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCall.java
@@ -26,7 +26,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({MustCallUnknown.class})
 @DefaultQualifierInHierarchy
-@DefaultFor({TypeUseLocation.EXCEPTION_PARAMETER})
+@DefaultFor({
+  TypeUseLocation.IMPLICIT_UPPER_BOUND,
+  TypeUseLocation.IMPLICIT_LOWER_BOUND,
+  TypeUseLocation.EXCEPTION_PARAMETER
+})
 public @interface MustCall {
   /**
    * Methods that must be called, on any expression whose type is annotated.

--- a/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCall.java
+++ b/must-call-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCall.java
@@ -26,11 +26,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({MustCallUnknown.class})
 @DefaultQualifierInHierarchy
-@DefaultFor({
-  TypeUseLocation.IMPLICIT_UPPER_BOUND,
-  TypeUseLocation.IMPLICIT_LOWER_BOUND,
-  TypeUseLocation.EXCEPTION_PARAMETER
-})
+@DefaultFor({TypeUseLocation.EXCEPTION_PARAMETER})
 public @interface MustCall {
   /**
    * Methods that must be called, on any expression whose type is annotated.


### PR DESCRIPTION
Making `@MustCall` the default for `IMPLICIT_UPPER_BOUND` definitely reduces annotation burden in my case studies (and might do so for other case studies).
I'm not sure whether making it the default for `IMPLICIT_LOWER_BOUND` is desirable.