### PR TITLE
Fix false positive when creating a must-call alias with a field

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -361,7 +361,11 @@ class MustCallInvokedChecker {
                 .toSet();
         defs.remove(setContainingMustCallAliasParamLocal);
         defs.add(newSetContainingMustCallAliasParamLocal);
-      } else if (!(sameResource instanceof LocalVariableNode)) {
+      } else if (!(sameResource instanceof LocalVariableNode
+          || sameResource instanceof FieldAccessNode)) {
+        // we do not track the temp var for the call if the MustCallAlias parameter is a local (that
+        // case is handled above; the local must already be in the defs) or a field (since handling
+        // of @Owning fields is a completely separate check)
         defs.add(ImmutableSet.of(lhsLocalVarWithTreeNew));
       }
     }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -364,8 +364,9 @@ class MustCallInvokedChecker {
       } else if (!(sameResource instanceof LocalVariableNode
           || sameResource instanceof FieldAccessNode)) {
         // we do not track the temp var for the call if the MustCallAlias parameter is a local (that
-        // case is handled above; the local must already be in the defs) or a field (since handling
-        // of @Owning fields is a completely separate check)
+        // case is handled above; the local must already be in the defs) or a field (handling of
+        // @Owning fields is a completely separate check, and we never need to track an alias of
+        // non-@Owning fields)
         defs.add(ImmutableSet.of(lhsLocalVarWithTreeNew));
       }
     }

--- a/object-construction-checker/tests/mustcall/MustCallAliasOwningField.java
+++ b/object-construction-checker/tests/mustcall/MustCallAliasOwningField.java
@@ -25,4 +25,8 @@ public @MustCall("shutdown") class MustCallAliasOwningField {
     public static void authenticate(InputStream is) {
 
     }
+
+    public void wrapField() {
+        DataInputStream dis = new DataInputStream(input);
+    }
 }


### PR DESCRIPTION
See the new test.  Before, we would report a false positive warning when creating a must-call alias with a field.  Since we handle `@Owning` fields completely separately, there is no need to track the result of a call when its `@MustCallAlias` parameter is the result of a field read.

Eventually, it may be cleaner to find a way to ignore field reads in one place, rather than adding special checks in multiple places.  But that would take more thought.