### PR TITLE
update to Checker Framework version 3.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 
 ext.versions = [
-    checkerFramework: "3.11.0",
+    checkerFramework: "3.12.0",
     autoValue       : "1.6.5",
     lombok          : "1.18.16",
 ]

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
@@ -196,9 +195,7 @@ public class MustCallTransfer extends CFTransfer {
       @SuppressWarnings("deprecation")
       List<AnnotationMirror> createsObligations =
           AnnotationUtils.getElementValueArray(
-              createsObligationList,
-              "value",
-              AnnotationMirror.class, true);
+              createsObligationList, "value", AnnotationMirror.class, true);
       Set<JavaExpression> results = new HashSet<>();
       if (currentPath == null) {
         currentPath = atypeFactory.getPath(n.getTree());
@@ -237,8 +234,7 @@ public class MustCallTransfer extends CFTransfer {
       TreePath currentPath) {
     @SuppressWarnings("deprecation")
     String targetStrWithoutAdaptation =
-        AnnotationUtils.getElementValue(
-            createsObligation, "value", String.class, true);
+        AnnotationUtils.getElementValue(createsObligation, "value", String.class, true);
     // Note that it *is* necessary to parse this string twice - the first time to standardize
     // and viewpoint adapt it via the utility method called on the next line, and the second
     // time (in the try block below) to actually get the relevant expression.

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.mustcall;
 
-import com.sun.source.tree.*;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import java.util.Collections;
 import java.util.HashSet;
@@ -12,16 +15,24 @@ import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.mustcall.qual.CreatesObligation;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
-import org.checkerframework.dataflow.cfg.node.*;
+import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
+import org.checkerframework.dataflow.cfg.node.StringConcatenateAssignmentNode;
+import org.checkerframework.dataflow.cfg.node.StringConcatenateNode;
+import org.checkerframework.dataflow.cfg.node.TernaryExpressionNode;
 import org.checkerframework.dataflow.expression.JavaExpression;
-import org.checkerframework.framework.flow.*;
-import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
-import org.checkerframework.framework.util.JavaExpressionParseUtil;
-import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionContext;
+import org.checkerframework.framework.flow.CFAnalysis;
+import org.checkerframework.framework.flow.CFStore;
+import org.checkerframework.framework.flow.CFTransfer;
+import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionParseException;
+import org.checkerframework.framework.util.StringToJavaExpression;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
@@ -29,15 +40,22 @@ import org.checkerframework.javacutil.TypesUtils;
 import org.checkerframework.javacutil.trees.TreeBuilder;
 
 /**
- * Transfer function for the must-call type system. Handles defaulting for string concatenations.
+ * Transfer function for the must-call type system. Handles defaulting for string concatenations and
+ * some logic for creating temporary variables for expressions.
  */
 public class MustCallTransfer extends CFTransfer {
 
   /** TreeBuilder for building new AST nodes */
   private final TreeBuilder treeBuilder;
 
+  /** The type factory */
   private MustCallAnnotatedTypeFactory atypeFactory;
 
+  /**
+   * Create a MustCallTransfer
+   *
+   * @param analysis the analysis
+   */
   public MustCallTransfer(CFAnalysis analysis) {
     super(analysis);
     atypeFactory = (MustCallAnnotatedTypeFactory) analysis.getTypeFactory();
@@ -111,6 +129,13 @@ public class MustCallTransfer extends CFTransfer {
     return result;
   }
 
+  /**
+   * Adds newAnno as the value for target to all stores contained in result.
+   *
+   * @param result a TransferResult containing one or more stores
+   * @param target a JavaExpression whose type is being modified
+   * @param newAnno the new type for target
+   */
   public void insertIntoStores(
       TransferResult<CFValue, CFStore> result, JavaExpression target, AnnotationMirror newAnno) {
     if (result.containsTwoStores()) {
@@ -136,7 +161,7 @@ public class MustCallTransfer extends CFTransfer {
    *     CreatesObligation method and the targets are parseable; the empty set otherwise.
    */
   public static Set<JavaExpression> getCreatesObligationExpressions(
-      MethodInvocationNode n, GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory) {
+      MethodInvocationNode n, MustCallAnnotatedTypeFactory atypeFactory) {
     return getCreatesObligationExpressions(n, atypeFactory, null);
   }
 
@@ -155,7 +180,7 @@ public class MustCallTransfer extends CFTransfer {
    */
   public static Set<JavaExpression> getCreatesObligationExpressions(
       MethodInvocationNode n,
-      GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory,
+      MustCallAnnotatedTypeFactory atypeFactory,
       @Nullable TreePath currentPath) {
     AnnotationMirror createsObligation =
         atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), CreatesObligation.class);
@@ -168,7 +193,9 @@ public class MustCallTransfer extends CFTransfer {
       // Handle a set of create obligation annotations.
       List<AnnotationMirror> createsObligations =
           AnnotationUtils.getElementValueArray(
-              createsObligationList, "value", AnnotationMirror.class, false);
+              createsObligationList,
+              atypeFactory.createsObligationListValueElement,
+              AnnotationMirror.class);
       Set<JavaExpression> results = new HashSet<>();
       if (currentPath == null) {
         currentPath = atypeFactory.getPath(n.getTree());
@@ -192,29 +219,32 @@ public class MustCallTransfer extends CFTransfer {
 
   /**
    * Implementation of parsing a single CreatesObligation annotation. See {@link
-   * #getCreatesObligationExpressions(MethodInvocationNode, GenericAnnotatedTypeFactory)}.
+   * #getCreatesObligationExpressions(MethodInvocationNode, MustCallAnnotatedTypeFactory)}.
    *
    * @param createsObligation a create obligation annotation
    * @param n the method invocation of a reset method
    * @param atypeFactory the type factory
+   * @param currentPath the current path
    * @return the java expression representing the target, or null if the target is unparseable
    */
   private static @Nullable JavaExpression getCreatesObligationExpressionsImpl(
       AnnotationMirror createsObligation,
       MethodInvocationNode n,
-      GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory,
+      MustCallAnnotatedTypeFactory atypeFactory,
       TreePath currentPath) {
+    // TODO: apparently the default value ("this") here needs to be supplied, for performance
+    // reasons. Is there a way to change this so
+    // that if the default value of the annotation element changes, this defaulting will change,
+    // too?
     String targetStrWithoutAdaptation =
-        AnnotationUtils.getElementValue(createsObligation, "value", String.class, true);
-    JavaExpressionContext context =
-        JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodUse(
-            n, atypeFactory.getChecker());
+        AnnotationUtils.getElementValue(
+            createsObligation, atypeFactory.createsObligationValueElement, String.class, "this");
     // Note that it *is* necessary to parse this string twice - the first time to standardize
     // and viewpoint adapt it via the utility method called on the next line, and the second
     // time (in the try block below) to actually get the relevant expression.
     String targetStr =
         MustCallTransfer.standardizeAndViewpointAdapt(
-            targetStrWithoutAdaptation, currentPath, context);
+            targetStrWithoutAdaptation, n, atypeFactory.getChecker());
     // TODO: find a way to also check if the target is a known tempvar, and if so return that. That
     // should
     // improve the quality of the error messages we give, e.g. in tests/socket/BindChannel.java.
@@ -234,15 +264,21 @@ public class MustCallTransfer extends CFTransfer {
     return targetExpr;
   }
 
-  /*
-   * Helper function to standardize and viewpoint adapt a String given a path and a context.
-   * Wraps JavaExpressionParseUtil#parse. If a parse exception is encountered, this returns
-   * its argument.
+  /**
+   * Helper function to standardize and viewpoint adapt a String within the context of a method
+   * invocation. Wraps JavaExpressionParseUtil#parse. If a parse exception is encountered, this
+   * returns its argument.
+   *
+   * @param s the string to standardize viewpoint adapt
+   * @param miNode the method invocation node in whose context s should be standardized and
+   *     viewpoint adapted
+   * @param checker the checker
+   * @return a standardized and viewpoint adapted view of s, or s if s could not be parsed
    */
   public static String standardizeAndViewpointAdapt(
-      String s, TreePath currentPath, JavaExpressionContext context) {
+      String s, MethodInvocationNode miNode, BaseTypeChecker checker) {
     try {
-      return JavaExpressionParseUtil.parse(s, context, currentPath).toString();
+      return StringToJavaExpression.atMethodInvocation(s, miNode, checker).toString();
     } catch (JavaExpressionParseException e) {
       return s;
     }
@@ -260,6 +296,14 @@ public class MustCallTransfer extends CFTransfer {
     return handleStringConcatenation(super.visitStringConcatenateAssignment(n, in));
   }
 
+  /**
+   * Create a new result for a string concatenation that forces their type to always be bottom.
+   * Without this logic, implicit string conversions can cause string-typed expressions to take on
+   * types from non-string arguments to a concatenation, which is undesirable.
+   *
+   * @param result the current transfer result
+   * @return the modified result
+   */
   private TransferResult<CFValue, CFStore> handleStringConcatenation(
       TransferResult<CFValue, CFStore> result) {
     TypeMirror underlyingType = result.getResultValue().getUnderlyingType();
@@ -289,6 +333,13 @@ public class MustCallTransfer extends CFTransfer {
     }
   }
 
+  /**
+   * Either returns the temporary variable associated with node, or creates one if one does not
+   * exist. node must be an expression, not a statement.
+   *
+   * @param node a node
+   * @return a temporary variable node representing node that can be placed into a store
+   */
   private @Nullable LocalVariableNode getOrCreateTempVar(Node node) {
     LocalVariableNode localVariableNode = atypeFactory.tempVars.get(node.getTree());
     if (localVariableNode == null) {
@@ -303,10 +354,17 @@ public class MustCallTransfer extends CFTransfer {
     return localVariableNode;
   }
 
-  protected @Nullable VariableTree createTemporaryVar(Node method) {
-    ExpressionTree tree = (ExpressionTree) method.getTree();
+  /**
+   * Creates a variable declaration for the given expression node, if possible.
+   *
+   * @param node an expression node
+   * @return a variable tree for the node, or null if an appropriate containing element cannot be
+   *     located
+   */
+  protected @Nullable VariableTree createTemporaryVar(Node node) {
+    ExpressionTree tree = (ExpressionTree) node.getTree();
     TypeMirror treeType = TreeUtils.typeOf(tree);
-    Element enclosingElement = null;
+    Element enclosingElement;
     TreePath path = atypeFactory.getPath(tree);
     if (path == null) {
       enclosingElement = TreeUtils.elementFromTree(tree).getEnclosingElement();
@@ -327,8 +385,16 @@ public class MustCallTransfer extends CFTransfer {
     return tmpVarTree;
   }
 
+  /** A unique identifier counter for node names. */
   protected long uid = 0;
 
+  /**
+   * Creates a unique name using the given prefix. Can be used up to Long.MAX_VALUE times for each
+   * prefix.
+   *
+   * @param prefix the prefix for the name
+   * @return a unique name that starts with the prefix
+   */
   protected String uniqueName(String prefix) {
     return prefix + "-" + uid++;
   }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -242,8 +242,7 @@ class MustCallInvokedChecker {
 
     TreePath currentPath = typeFactory.getPath(node.getTree());
     Set<JavaExpression> targetExprs =
-        MustCallTransfer.getCreatesObligationExpressions(
-            node, typeFactory, currentPath);
+        MustCallTransfer.getCreatesObligationExpressions(node, typeFactory, currentPath);
     Set<JavaExpression> missing = new HashSet<>();
     for (JavaExpression target : targetExprs) {
       if (target instanceof LocalVariable) {
@@ -300,8 +299,8 @@ class MustCallInvokedChecker {
           String enclosingTargetStr;
           try {
             enclosingTargetStr =
-                StringToJavaExpression.atMethodDecl(
-                        enclosingTargetStrWithoutAdaptation, enclosingElt, checker)
+                StringToJavaExpression.atMethodBody(
+                        enclosingTargetStrWithoutAdaptation, enclosingMethod, checker)
                     .toString();
           } catch (JavaExpressionParseException e) {
             enclosingTargetStr = enclosingTargetStrWithoutAdaptation;
@@ -794,7 +793,8 @@ class MustCallInvokedChecker {
       String targetStr = null;
       try {
         targetStr =
-            StringToJavaExpression.atMethodDecl(targetStrWithoutAdaptation, enclosingElt, checker)
+            StringToJavaExpression.atMethodBody(
+                    targetStrWithoutAdaptation, enclosingMethod, checker)
                 .toString();
       } catch (JavaExpressionParseException e) {
         targetStr = targetStrWithoutAdaptation;

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -38,7 +38,6 @@ import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.com.google.common.base.Predicates;
 import org.checkerframework.com.google.common.collect.FluentIterable;
 import org.checkerframework.com.google.common.collect.ImmutableSet;
-import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.dataflow.cfg.block.Block;
@@ -62,8 +61,8 @@ import org.checkerframework.dataflow.expression.LocalVariable;
 import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
-import org.checkerframework.framework.util.JavaExpressionParseUtil;
-import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionContext;
+import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionParseException;
+import org.checkerframework.framework.util.StringToJavaExpression;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
@@ -243,7 +242,8 @@ class MustCallInvokedChecker {
 
     TreePath currentPath = typeFactory.getPath(node.getTree());
     Set<JavaExpression> targetExprs =
-        MustCallTransfer.getCreatesObligationExpressions(node, typeFactory, currentPath);
+        MustCallTransfer.getCreatesObligationExpressions(
+            node, typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class), currentPath);
     Set<JavaExpression> missing = new HashSet<>();
     for (JavaExpression target : targetExprs) {
       if (target instanceof LocalVariable) {
@@ -292,15 +292,20 @@ class MustCallInvokedChecker {
         AnnotationMirror enclosingCreatesObligation =
             typeFactory.getDeclAnnotation(enclosingElt, CreatesObligation.class);
         if (enclosingCreatesObligation != null) {
+          MustCallAnnotatedTypeFactory mcAtf =
+              typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
           String enclosingTargetStrWithoutAdaptation =
               AnnotationUtils.getElementValue(
-                  enclosingCreatesObligation, "value", String.class, true);
-          JavaExpressionContext enclosingContext =
-              JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodDeclaration(
-                  enclosingMethod, checker);
-          String enclosingTargetStr =
-              MustCallTransfer.standardizeAndViewpointAdapt(
-                  enclosingTargetStrWithoutAdaptation, currentPath, enclosingContext);
+                  enclosingCreatesObligation, mcAtf.createsObligationValueElement, String.class);
+          String enclosingTargetStr;
+          try {
+            enclosingTargetStr =
+                StringToJavaExpression.atMethodDecl(
+                        enclosingTargetStrWithoutAdaptation, enclosingElt, checker)
+                    .toString();
+          } catch (JavaExpressionParseException e) {
+            enclosingTargetStr = enclosingTargetStrWithoutAdaptation;
+          }
           if (enclosingTargetStr.equals(target.toString())) {
             // The enclosing method also has a corresponding CreatesObligation annotation, so this
             // satisfies case 3.
@@ -473,7 +478,10 @@ class MustCallInvokedChecker {
         Set<AnnotationMirror> annotationMirrors = typeFactory.getDeclAnnotations(formal);
 
         if (annotationMirrors.stream()
-            .anyMatch(anno -> AnnotationUtils.areSameByClass(anno, Owning.class))) {
+            .anyMatch(
+                anno ->
+                    AnnotationUtils.areSameByName(
+                        anno, "org.checkerframework.checker.objectconstruction.qual.Owning"))) {
           // transfer ownership!
           newDefs.remove(getSetContainingAssignmentTreeOfVar(newDefs, local));
         }
@@ -693,7 +701,9 @@ class MustCallInvokedChecker {
     AnnotationMirror mcAnno =
         mcTypeFactory.getAnnotationFromJavaExpression(
             JavaExpression.fromNode(lhs), node.getTree(), MustCall.class);
-    List<String> mcValues = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(mcAnno);
+    List<String> mcValues =
+        AnnotationUtils.getElementValueArray(
+            mcAnno, mcTypeFactory.mustCallValueElement, String.class);
 
     if (mcValues.isEmpty()) {
       return;
@@ -705,7 +715,10 @@ class MustCallInvokedChecker {
         cmValue == null
             ? typeFactory.top
             : cmValue.getAnnotations().stream()
-                .filter(anno -> AnnotationUtils.areSameByClass(anno, CalledMethods.class))
+                .filter(
+                    anno ->
+                        AnnotationUtils.areSameByName(
+                            anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods"))
                 .findAny()
                 .orElse(typeFactory.top);
 
@@ -757,29 +770,35 @@ class MustCallInvokedChecker {
     }
 
     Set<String> targetStrsWithoutAdaptation;
+    MustCallAnnotatedTypeFactory mcAtf =
+        typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
     if (createsObligation != null) {
       targetStrsWithoutAdaptation =
           Collections.singleton(
-              AnnotationUtils.getElementValue(createsObligation, "value", String.class, true));
+              AnnotationUtils.getElementValue(
+                  createsObligation, mcAtf.createsObligationValueElement, String.class, "this"));
     } else {
       // multiple create obligations
       List<AnnotationMirror> createsObligationAnnos =
           AnnotationUtils.getElementValueArray(
-              createsObligations, "value", AnnotationMirror.class, false);
+              createsObligations, mcAtf.createsObligationListValueElement, AnnotationMirror.class);
       targetStrsWithoutAdaptation = new HashSet<>();
       for (AnnotationMirror co : createsObligationAnnos) {
         targetStrsWithoutAdaptation.add(
-            AnnotationUtils.getElementValue(co, "value", String.class, true));
+            AnnotationUtils.getElementValue(
+                co, mcAtf.createsObligationValueElement, String.class, "this"));
       }
     }
-    JavaExpressionContext context =
-        JavaExpressionParseUtil.JavaExpressionContext.buildContextForMethodDeclaration(
-            enclosingMethod, checker);
     String checked = "";
     for (String targetStrWithoutAdaptation : targetStrsWithoutAdaptation) {
-      String targetStr =
-          MustCallTransfer.standardizeAndViewpointAdapt(
-              targetStrWithoutAdaptation, currentPath, context);
+      String targetStr = null;
+      try {
+        targetStr =
+            StringToJavaExpression.atMethodDecl(targetStrWithoutAdaptation, enclosingElt, checker)
+                .toString();
+      } catch (JavaExpressionParseException e) {
+        targetStr = targetStrWithoutAdaptation;
+      }
       if (targetStr.equals(receiverString)) {
         // This create obligation annotation matches.
         return;
@@ -1142,7 +1161,10 @@ class MustCallInvokedChecker {
       if (lhsCFValue != null) { // When store contains the lhs
         cmAnno =
             lhsCFValue.getAnnotations().stream()
-                .filter(anno -> AnnotationUtils.areSameByClass(anno, CalledMethods.class))
+                .filter(
+                    anno ->
+                        AnnotationUtils.areSameByName(
+                            anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods"))
                 .findAny()
                 .orElse(typeFactory.top);
       } else {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -243,7 +243,7 @@ class MustCallInvokedChecker {
     TreePath currentPath = typeFactory.getPath(node.getTree());
     Set<JavaExpression> targetExprs =
         MustCallTransfer.getCreatesObligationExpressions(
-            node, typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class), currentPath);
+            node, typeFactory, currentPath);
     Set<JavaExpression> missing = new HashSet<>();
     for (JavaExpression target : targetExprs) {
       if (target instanceof LocalVariable) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -159,7 +159,7 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
       mcLub = mustCallAnnotatedTypeFactory.getQualifierHierarchy().leastUpperBound(mcLub, mcAnno);
     }
     if (AnnotationUtils.areSameByName(
-        mcLub, "org.checkeframework.checker.mustcall.qual.MustCall")) {
+        mcLub, "org.checkerframework.checker.mustcall.qual.MustCall")) {
       return getMustCallValues(mcLub);
     } else {
       return null;

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionAnnotatedTypeFactory.java
@@ -17,6 +17,7 @@ import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFact
 import org.checkerframework.checker.calledmethods.qual.CalledMethods;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsBottom;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsPredicate;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.MustCallAnnotatedTypeFactory;
 import org.checkerframework.checker.mustcall.MustCallChecker;
 import org.checkerframework.checker.mustcall.MustCallNoAccumulationFramesChecker;
@@ -25,9 +26,9 @@ import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.MustCallInvokedChecker.LocalVarWithTree;
+import org.checkerframework.checker.objectconstruction.qual.EnsuresCalledMethodsVarArgs;
 import org.checkerframework.com.google.common.collect.ImmutableSet;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
@@ -46,6 +47,18 @@ import org.checkerframework.javacutil.TypesUtils;
  * subtyping rules between @CalledMethod annotations.
  */
 public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotatedTypeFactory {
+
+  final ExecutableElement calledMethodsValueElement =
+      TreeUtils.getMethod(CalledMethods.class, "value", 0, processingEnv);
+
+  final ExecutableElement ensuresCalledMethodsVarArgsValueElement =
+      TreeUtils.getMethod(EnsuresCalledMethodsVarArgs.class, "value", 0, processingEnv);
+
+  final ExecutableElement ensuresCalledMethodsValueElement =
+      TreeUtils.getMethod(EnsuresCalledMethods.class, "value", 0, processingEnv);
+
+  final ExecutableElement ensuresCalledMethodsMethodsElement =
+      TreeUtils.getMethod(EnsuresCalledMethods.class, "methods", 0, processingEnv);
 
   /**
    * Bidirectional map to preserve temporary variables created for nodes with non-empty @MustCall
@@ -115,7 +128,10 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
       if (value != null) {
         mcAnno =
             value.getAnnotations().stream()
-                .filter(anno -> AnnotationUtils.areSameByClass(anno, MustCall.class))
+                .filter(
+                    anno ->
+                        AnnotationUtils.areSameByName(
+                            anno, "org.checkerframework.checker.mustcall.qual.MustCall"))
                 .findAny()
                 .orElse(null);
       }
@@ -142,8 +158,12 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
       }
       mcLub = mustCallAnnotatedTypeFactory.getQualifierHierarchy().leastUpperBound(mcLub, mcAnno);
     }
-
-    return getMustCallValues(mcLub);
+    if (AnnotationUtils.areSameByName(
+        mcLub, "org.checkeframework.checker.mustcall.qual.MustCall")) {
+      return getMustCallValues(mcLub);
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -181,9 +201,11 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
   }
 
   private List<String> getMustCallValues(AnnotationMirror mustCallAnnotation) {
+    MustCallAnnotatedTypeFactory mcAtf = getTypeFactoryOfSubchecker(MustCallChecker.class);
     List<String> mustCallValues =
         (mustCallAnnotation != null)
-            ? ValueCheckerUtils.getValueOfAnnotationWithStringArgument(mustCallAnnotation)
+            ? AnnotationUtils.getElementValueArray(
+                mustCallAnnotation, mcAtf.mustCallValueElement, String.class)
             : Collections.emptyList();
     return mustCallValues;
   }
@@ -231,7 +253,8 @@ public class ObjectConstructionAnnotatedTypeFactory extends CalledMethodsAnnotat
   }
 
   public boolean useAccumulationFrames() {
-    return !checker.hasOption(MustCallChecker.NO_ACCUMULATION_FRAMES);
+    return checker.hasOption(ObjectConstructionChecker.CHECK_MUST_CALL)
+        && !checker.hasOption(MustCallChecker.NO_ACCUMULATION_FRAMES);
   }
 
   @Override

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -265,8 +265,7 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
                 AnnotationUtils.getElementValueArray(
                     anno, atypeFactory.calledMethodsValueElement, String.class);
             // valuesAsList cannot have its length changed -- it is backed by an
-            // array.  getElementValueArray returns a new,
-            // modifiable list.
+            // array.  getElementValueArray returns a new, modifiable list.
             oldFlowValues.addAll(valuesAsList);
             valuesAsList = oldFlowValues;
           }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -13,13 +13,11 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.calledmethods.CalledMethodsTransfer;
-import org.checkerframework.checker.calledmethods.qual.CalledMethodsPredicate;
 import org.checkerframework.checker.mustcall.MustCallAnnotatedTypeFactory;
 import org.checkerframework.checker.mustcall.MustCallChecker;
 import org.checkerframework.checker.mustcall.MustCallTransfer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.objectconstruction.qual.EnsuresCalledMethodsVarArgs;
-import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
@@ -124,7 +122,8 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
     }
 
     Set<JavaExpression> targetExprs =
-        MustCallTransfer.getCreatesObligationExpressions(n, atypeFactory);
+        MustCallTransfer.getCreatesObligationExpressions(
+            n, atypeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class));
     for (JavaExpression targetExpr : targetExprs) {
       AnnotationMirror defaultType = atypeFactory.top;
       if (result.containsTwoStores()) {
@@ -190,7 +189,8 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
 
     // Don't attempt to strengthen @CalledMethodsPredicate annotations, because that would
     // require reasoning about the predicate itself. Instead, start over from top.
-    if (AnnotationUtils.areSameByClass(type, CalledMethodsPredicate.class)) {
+    if (AnnotationUtils.areSameByName(
+        type, "org.checkerframework.checker.calledmethods.qual.CalledMethodsPredicate")) {
       type = atypeFactory.top;
     }
 
@@ -198,7 +198,9 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
       return null;
     }
 
-    List<String> currentMethods = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(type);
+    List<String> currentMethods =
+        AnnotationUtils.getElementValueArray(
+            type, atypeFactory.calledMethodsValueElement, String.class);
     List<String> newList =
         Stream.concat(Arrays.stream(methodNames), currentMethods.stream())
             .collect(Collectors.toList());
@@ -215,7 +217,8 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
       return;
     }
     String[] ensuredMethodNames =
-        AnnotationUtils.getElementValueArray(annot, "value", String.class, true)
+        AnnotationUtils.getElementValueArray(
+                annot, atypeFactory.ensuresCalledMethodsVarArgsValueElement, String.class)
             .toArray(new String[0]);
     List<? extends VariableElement> parameters = elt.getParameters();
     int varArgsPos = parameters.size() - 1;
@@ -260,14 +263,13 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
         for (AnnotationMirror anno : flowAnnos) {
           if (atypeFactory.isAccumulatorAnnotation(anno)) {
             List<String> oldFlowValues =
-                ValueCheckerUtils.getValueOfAnnotationWithStringArgument(anno);
-            if (oldFlowValues != null) {
-              // valuesAsList cannot have its length changed -- it is backed by an
-              // array.  getValueOfAnnotationWithStringArgument returns a new,
-              // modifiable list.
-              oldFlowValues.addAll(valuesAsList);
-              valuesAsList = oldFlowValues;
-            }
+                AnnotationUtils.getElementValueArray(
+                    anno, atypeFactory.calledMethodsValueElement, String.class);
+            // valuesAsList cannot have its length changed -- it is backed by an
+            // array.  getElementValueArray returns a new,
+            // modifiable list.
+            oldFlowValues.addAll(valuesAsList);
+            valuesAsList = oldFlowValues;
           }
         }
       }

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionTransfer.java
@@ -122,8 +122,7 @@ public class ObjectConstructionTransfer extends CalledMethodsTransfer {
     }
 
     Set<JavaExpression> targetExprs =
-        MustCallTransfer.getCreatesObligationExpressions(
-            n, atypeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class));
+        MustCallTransfer.getCreatesObligationExpressions(n, atypeFactory);
     for (JavaExpression targetExpr : targetExprs) {
       AnnotationMirror defaultType = atypeFactory.top;
       if (result.containsTwoStores()) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -17,7 +17,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.objectconstruction.qual.EnsuresCalledMethodsVarArgs;
 import org.checkerframework.checker.objectconstruction.qual.Owning;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.framework.source.DiagMessage;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
@@ -44,7 +43,8 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
   @Override
   public Void visitAnnotation(final AnnotationTree node, final Void p) {
     AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
-    if (AnnotationUtils.areSameByClass(anno, EnsuresCalledMethodsVarArgs.class)) {
+    if (AnnotationUtils.areSameByName(
+        anno, "org.checkerframework.checker.objectconstruction.qual.EnsuresCalledMethodsVarArgs")) {
       // we can't verify these yet.  emit an error (which will have to be suppressed) for now
       checker.report(node, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.unverified"));
       return null;
@@ -117,13 +117,17 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
 
             if (ensuresCalledMethodsAnno != null) {
               List<String> values =
-                  ValueCheckerUtils.getValueOfAnnotationWithStringArgument(
-                      ensuresCalledMethodsAnno);
+                  AnnotationUtils.getElementValueArray(
+                      ensuresCalledMethodsAnno,
+                      atypeFactory.ensuresCalledMethodsValueElement,
+                      String.class);
               if (values.stream()
                   .anyMatch(value -> value.contains(field.getSimpleName().toString()))) {
                 List<String> methods =
                     AnnotationUtils.getElementValueArray(
-                        ensuresCalledMethodsAnno, "methods", String.class, false);
+                        ensuresCalledMethodsAnno,
+                        atypeFactory.ensuresCalledMethodsMethodsElement,
+                        String.class);
                 fieldMCAnno.removeAll(methods);
               }
             }


### PR DESCRIPTION
Sorry that there are some extraneous changes in the Must Call Checker itself (i.e. adding docs, etc) - I copied the versions of those files from my PR against the CF proper, so they follow its javadoc guidelines.

I left intact a few uses of deprecated `getElementValueArray` calls, to avoid duplicating code. We probably should remove these, but it's a pain, because the code is shared between two different checkers and their type factories are taken as parameters (i.e. as `GenericAnnotatedTypeFactory`) depending on which checker uses the (static) method. Both need to get the same element from several shared annotations, so to fix this we'd need to create a subclass of GATF for them both to extend that has `ExecutableElement` fields for each of the annotation elements that these methods need to use.