### PR TITLE
require that creates obligation targets aren't added when overriding methods

### DIFF
--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -248,6 +248,7 @@ public class MustCallTransfer extends CFTransfer {
               targetStrWithoutAdaptation, n, atypeFactory.getChecker());
       if (targetExpr instanceof Unknown) {
         issueUnparseableError(n, atypeFactory, targetStrWithoutAdaptation);
+        return null;
       }
     } catch (JavaExpressionParseException e) {
       issueUnparseableError(n, atypeFactory, targetStrWithoutAdaptation);

--- a/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/must-call-checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -183,14 +183,10 @@ public class MustCallTransfer extends CFTransfer {
       MethodInvocationNode n,
       GenericAnnotatedTypeFactory<?, ?, ?, ?> atypeFactory,
       @Nullable TreePath currentPath) {
-    AnnotationMirror createsObligation =
-        atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), CreatesObligation.class);
-    if (createsObligation == null) {
-      AnnotationMirror createsObligationList =
-          atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), CreatesObligation.List.class);
-      if (createsObligationList == null) {
-        return Collections.emptySet();
-      }
+
+    AnnotationMirror createsObligationList =
+            atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), CreatesObligation.List.class);
+    if (createsObligationList != null) {
       // Handle a set of create obligation annotations.
       @SuppressWarnings("deprecation")
       List<AnnotationMirror> createsObligations =
@@ -208,6 +204,12 @@ public class MustCallTransfer extends CFTransfer {
       }
       return results;
     }
+    AnnotationMirror createsObligation =
+            atypeFactory.getDeclAnnotation(n.getTarget().getMethod(), CreatesObligation.class);
+    if (createsObligation == null) {
+      return Collections.emptySet();
+    }
+
     // Handle a single create obligation annotation.
     if (currentPath == null) {
       currentPath = atypeFactory.getPath(n.getTree());

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -295,7 +295,7 @@ class MustCallInvokedChecker {
               typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
           String enclosingTargetStrWithoutAdaptation =
               AnnotationUtils.getElementValue(
-                  enclosingCreatesObligation, mcAtf.createsObligationValueElement, String.class);
+                  enclosingCreatesObligation, mcAtf.createsObligationValueElement, String.class, "this");
           String enclosingTargetStr;
           try {
             enclosingTargetStr =

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -295,7 +295,10 @@ class MustCallInvokedChecker {
               typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
           String enclosingTargetStrWithoutAdaptation =
               AnnotationUtils.getElementValue(
-                  enclosingCreatesObligation, mcAtf.createsObligationValueElement, String.class, "this");
+                  enclosingCreatesObligation,
+                  mcAtf.createsObligationValueElement,
+                  String.class,
+                  "this");
           String enclosingTargetStr;
           try {
             enclosingTargetStr =

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java
@@ -97,6 +97,9 @@ public class ObjectConstructionChecker extends CalledMethodsChecker {
     messages.setProperty(
         "reset.not.owning",
         "Calling this method resets the must-call obligations of the expression %s, which is non-owning. Either annotate its declaration with an @Owning annotation or write a corresponding @CreatesObligation annotation on the method that encloses this statement.\n");
+    messages.setProperty(
+        "creates.obligation.override.invalid",
+        "Method %s cannot override method %s, which defines fewer @CreatesObligation targets.\nfound:    %s\nrequired: %s\n");
     return messages;
   }
 

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -81,13 +81,15 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
         if (!overriddenCoValues.containsAll(coValues)) {
           String foundCoValueString = String.join(", ", coValues);
           String neededCoValueString = String.join(", ", overriddenCoValues);
+          String actualClassname = ElementUtils.getEnclosingClassName(elt);
+          String overriddenClassname = ElementUtils.getEnclosingClassName(overridden);
           checker.reportError(
               node,
               "creates.obligation.override.invalid",
-              elt,
-              overridden,
-              coValues,
-              overriddenCoValues);
+              actualClassname + "#" + elt,
+              overriddenClassname + "#" + overridden,
+              foundCoValueString,
+              neededCoValueString);
         }
       }
     }
@@ -121,14 +123,6 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
    *     modifiable if it is non-empty.
    */
   private List<String> getCOValues(ExecutableElement elt, MustCallAnnotatedTypeFactory mcAtf) {
-    AnnotationMirror createsObligation =
-        atypeFactory.getDeclAnnotation(elt, CreatesObligation.class);
-    if (createsObligation != null) {
-      // don't use Collections.singletonList because it's not guaranteed to be mutable
-      List<String> result = new ArrayList<>(1);
-      result.add(getCOValue(createsObligation, mcAtf));
-      return result;
-    }
     AnnotationMirror createsObligationList =
         atypeFactory.getDeclAnnotation(elt, CreatesObligation.List.class);
     if (createsObligationList != null) {
@@ -141,6 +135,14 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
       for (AnnotationMirror co : createObligations) {
         result.add(getCOValue(co, mcAtf));
       }
+      return result;
+    }
+    AnnotationMirror createsObligation =
+        atypeFactory.getDeclAnnotation(elt, CreatesObligation.class);
+    if (createsObligation != null) {
+      // don't use Collections.singletonList because it's not guaranteed to be mutable
+      List<String> result = new ArrayList<>(1);
+      result.add(getCOValue(createsObligation, mcAtf));
       return result;
     }
     return Collections.emptyList();

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -123,7 +123,10 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
    *     iff there are no @CreatesObligation annotations on elt. The returned list is always
    *     modifiable if it is non-empty.
    */
-  /*package-private*/ static List<String> getCOValues(ExecutableElement elt, MustCallAnnotatedTypeFactory mcAtf, ObjectConstructionAnnotatedTypeFactory atypeFactory) {
+  /*package-private*/ static List<String> getCOValues(
+      ExecutableElement elt,
+      MustCallAnnotatedTypeFactory mcAtf,
+      ObjectConstructionAnnotatedTypeFactory atypeFactory) {
     AnnotationMirror createsObligationList =
         atypeFactory.getDeclAnnotation(elt, CreatesObligation.List.class);
     if (createsObligationList != null) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionVisitor.java
@@ -69,7 +69,7 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
     }
     MustCallAnnotatedTypeFactory mcAtf =
         atypeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
-    List<String> coValues = getCOValues(elt, mcAtf);
+    List<String> coValues = getCOValues(elt, mcAtf, atypeFactory);
     if (!coValues.isEmpty()) {
       // Check the validity of the annotation, by ensuring that if this method is overriding another
       // method
@@ -77,7 +77,7 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
       // allow e.g. a field to
       // be overwritten by a CO method, but the CO effect wouldn't occur.
       for (ExecutableElement overridden : ElementUtils.getOverriddenMethods(elt, this.types)) {
-        List<String> overriddenCoValues = getCOValues(overridden, mcAtf);
+        List<String> overriddenCoValues = getCOValues(overridden, mcAtf, atypeFactory);
         if (!overriddenCoValues.containsAll(coValues)) {
           String foundCoValueString = String.join(", ", coValues);
           String neededCoValueString = String.join(", ", overriddenCoValues);
@@ -104,7 +104,7 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
    * @param mcAtf a MustCallAnnotatedTypeFactory, to source the value element
    * @return the string value
    */
-  private String getCOValue(
+  private static String getCOValue(
       AnnotationMirror createsObligation, MustCallAnnotatedTypeFactory mcAtf) {
     return AnnotationUtils.getElementValue(
         createsObligation, mcAtf.createsObligationValueElement, String.class, "this");
@@ -117,12 +117,13 @@ public class ObjectConstructionVisitor extends CalledMethodsVisitor {
    *
    * @param elt an executable element
    * @param mcAtf a MustCallAnnotatedTypeFactory, to source the value element
+   * @param atypeFactory a ObjectConstructionAnnotatedTypeFactory
    * @return the literal strings present in the @CreatesObligation annotation(s) of that element,
    *     substituting the default "this" for empty annotations. This method returns the empty list
    *     iff there are no @CreatesObligation annotations on elt. The returned list is always
    *     modifiable if it is non-empty.
    */
-  private List<String> getCOValues(ExecutableElement elt, MustCallAnnotatedTypeFactory mcAtf) {
+  /*package-private*/ static List<String> getCOValues(ExecutableElement elt, MustCallAnnotatedTypeFactory mcAtf, ObjectConstructionAnnotatedTypeFactory atypeFactory) {
     AnnotationMirror createsObligationList =
         atypeFactory.getDeclAnnotation(elt, CreatesObligation.List.class);
     if (createsObligationList != null) {

--- a/object-construction-checker/tests/mustcall/COAnonymousClass.java
+++ b/object-construction-checker/tests/mustcall/COAnonymousClass.java
@@ -1,0 +1,27 @@
+// Test case for https://github.com/kelloggm/object-construction-checker/issues/368
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+class COAnonymousClass {
+    static class Foo {
+
+        @CreatesObligation("this")
+        void resetFoo() { }
+
+        void other() {
+
+            Runnable r = new Runnable() {
+                @Override
+                // :: error: creates.obligation.override.invalid
+                @CreatesObligation
+                public void run() {
+                    resetFoo();
+                }
+            };
+            other2(r);
+        }
+
+        // If this call to run() were permitted with no errors, this would be unsound.
+        void other2(Runnable r) { r.run(); }
+    }
+}

--- a/object-construction-checker/tests/mustcall/COAnonymousClass.java
+++ b/object-construction-checker/tests/mustcall/COAnonymousClass.java
@@ -12,8 +12,8 @@ class COAnonymousClass {
 
             Runnable r = new Runnable() {
                 @Override
-                // :: error: creates.obligation.override.invalid
                 @CreatesObligation
+                // :: error: creates.obligation.override.invalid
                 public void run() {
                     resetFoo();
                 }

--- a/object-construction-checker/tests/mustcall/COAnonymousClass.java
+++ b/object-construction-checker/tests/mustcall/COAnonymousClass.java
@@ -12,16 +12,36 @@ class COAnonymousClass {
 
             Runnable r = new Runnable() {
                 @Override
-                @CreatesObligation
+                @CreatesObligation("Foo.this")
                 // :: error: creates.obligation.override.invalid
                 public void run() {
+                    // Ideally, we would not issue the following error. However, the Checker Framework's
+                    // JavaExpression support (https://checkerframework.org/manual/#java-expressions-as-arguments)
+                    // treats all versions of "this" (including "Foo.this") as referring to the object
+                    // that directly contains the annotation, so we treat this call to resetFoo as not permitted.
+                    // :: error: reset.not.owning
                     resetFoo();
                 }
             };
-            other2(r);
+            call_run(r);
+        }
+
+        void other2() {
+
+            Runnable r = new Runnable() {
+                @Override
+                @CreatesObligation("this")
+                // :: error: creates.obligation.override.invalid
+                public void run() {
+                    // This error definitely must be issued, since Foo.this != this.
+                    // :: error: reset.not.owning
+                    resetFoo();
+                }
+            };
+            call_run(r);
         }
 
         // If this call to run() were permitted with no errors, this would be unsound.
-        void other2(Runnable r) { r.run(); }
+        void call_run(Runnable r) { r.run(); }
     }
 }

--- a/object-construction-checker/tests/mustcall/COAnonymousClass.java
+++ b/object-construction-checker/tests/mustcall/COAnonymousClass.java
@@ -1,0 +1,27 @@
+// Test case for https://github.com/kelloggm/object-construction-checker/issues/368
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+class COAnonymousClass {
+    static class Foo {
+
+        @CreatesObligation("this")
+        void resetFoo() { }
+
+        void other() {
+
+            Runnable r = new Runnable() {
+                @Override
+                @CreatesObligation
+                // :: error: creates.obligation.override.invalid
+                public void run() {
+                    resetFoo();
+                }
+            };
+            other2(r);
+        }
+
+        // If this call to run() were permitted with no errors, this would be unsound.
+        void other2(Runnable r) { r.run(); }
+    }
+}

--- a/object-construction-checker/tests/mustcall/CreatesObligationIndirect.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationIndirect.java
@@ -41,7 +41,9 @@ class CreatesObligationIndirect {
     public static void reset_local3() {
         // :: error: required.method.not.called
         CreatesObligationIndirect r = new CreatesObligationIndirect();
-        // :: error: mustcall.not.parseable :: error: reset.not.owning
+        // Ideally, we'd issue a reset.not.owning error on the next line instead, but not being able to parse
+        // the case and requiring it to be in a local var is okay too.
+        // :: error: mustcall.not.parseable
         ((CreatesObligationIndirect) r).reset();
     }
 

--- a/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
@@ -2,7 +2,7 @@
 
 import org.checkerframework.checker.mustcall.qual.*;
 
-class COAnonymousClass {
+class CreatesObligationInnerClass {
     static class Foo {
 
         @CreatesObligation("this")
@@ -23,5 +23,24 @@ class COAnonymousClass {
 
         // If this call to run() were permitted with no errors, this would be unsound.
         void other2(Runnable r) { r.run(); }
+
+        /**
+         * non-static inner class
+         */
+        class Bar {
+
+            // this should be disallowed! not sure of the right error message
+            // :: error: creates.obligation.override.invalid
+            @CreatesObligation
+            void bar() {
+                resetFoo();
+            }
+        }
+
+        void callBar() {
+            Bar b = new Bar();
+            // If this call to bar() were permitted with no errors, this would be unsound.
+            b.bar();
+        }
     }
 }

--- a/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
@@ -12,11 +12,10 @@ class CreatesObligationInnerClass {
          * non-static inner class
          */
         class Bar {
-
             // this should be disallowed! not sure of the right error message
-            // :: error: creates.obligation.override.invalid
             @CreatesObligation
             void bar() {
+                // :: error: reset.not.owning
                 resetFoo();
             }
         }

--- a/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
@@ -12,7 +12,6 @@ class CreatesObligationInnerClass {
          * non-static inner class
          */
         class Bar {
-            // this should be disallowed! not sure of the right error message
             @CreatesObligation
             void bar() {
                 // :: error: reset.not.owning

--- a/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationInnerClass.java
@@ -8,22 +8,6 @@ class CreatesObligationInnerClass {
         @CreatesObligation("this")
         void resetFoo() { }
 
-        void other() {
-
-            Runnable r = new Runnable() {
-                @Override
-                @CreatesObligation
-                // :: error: creates.obligation.override.invalid
-                public void run() {
-                    resetFoo();
-                }
-            };
-            other2(r);
-        }
-
-        // If this call to run() were permitted with no errors, this would be unsound.
-        void other2(Runnable r) { r.run(); }
-
         /**
          * non-static inner class
          */

--- a/object-construction-checker/tests/mustcall/CreatesObligationOverride.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationOverride.java
@@ -1,0 +1,30 @@
+// A test case that a create-obligation method cannot be called via dynamic dispatch
+// without resetting the obligation.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("a")
+class CreatesObligationOverride {
+    @CreatesObligation
+    @Override
+    // :: error: creates.obligation.override.invalid
+    public String toString() { return "this method could re-assign a field or do something else it shouldn't"; }
+
+    public void a() { }
+
+    public static void test_no_cast() {
+        // :: error: required.method.not.called
+        CreatesObligationOverride co = new CreatesObligationOverride();
+        co.a();
+        co.toString();
+    }
+
+    public static void test_cast() {
+        // it would be ideal if the checker issued an error directly here, but the best we can do is
+        // issue the error above when the offending version of toString() is defined
+        CreatesObligationOverride co = new CreatesObligationOverride();
+        co.a();
+        Object o = co;
+        o.toString();
+    }
+}

--- a/object-construction-checker/tests/mustcall/CreatesObligationOverride2.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationOverride2.java
@@ -1,0 +1,81 @@
+// This test checks that 1) writing a CO annotation on an overridden method that's also
+// CO is permitted, and 2) that all overridden versions of a CO method are always also CO.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+class CreatesObligationOverride2 {
+
+    @InheritableMustCall("a")
+    static class Foo {
+
+        @CreatesObligation
+        public void b() { }
+
+        public void a() { }
+    }
+
+    static class Bar extends Foo {
+
+        @Override
+        @CreatesObligation
+        public void b() { }
+    }
+
+    static class Baz extends Foo {
+
+    }
+
+    static class Qux extends Foo {
+        @Override
+        public void b() { }
+    }
+
+    static void test1() {
+        // :: error: required.method.not.called
+        Foo foo = new Foo();
+        foo.a();
+        foo.b();
+    }
+
+    static void test2() {
+        // :: error: required.method.not.called
+        Foo foo = new Bar();
+        foo.a();
+        foo.b();
+    }
+
+    static void test3() {
+        // :: error: required.method.not.called
+        Foo foo = new Baz();
+        foo.a();
+        foo.b();
+    }
+
+    static void test4() {
+        // :: error: required.method.not.called
+        Foo foo = new Qux();
+        foo.a();
+        foo.b();
+    }
+
+    static void test5() {
+        // :: error: required.method.not.called
+        Bar foo = new Bar();
+        foo.a();
+        foo.b();
+    }
+
+    static void test6() {
+        // :: error: required.method.not.called
+        Baz foo = new Baz();
+        foo.a();
+        foo.b();
+    }
+
+    static void test7() {
+        // :: error: required.method.not.called
+        Qux foo = new Qux();
+        foo.a();
+        foo.b();
+    }
+}

--- a/object-construction-checker/tests/mustcall/CreatesObligationOverride2.java
+++ b/object-construction-checker/tests/mustcall/CreatesObligationOverride2.java
@@ -43,6 +43,7 @@ class CreatesObligationOverride2 {
             myFoo.a();
         }
 
+        // this version isn't permitted, since it adds a new obligation
         @Override
         @CreatesObligation("this.myFoo")
         // :: error: creates.obligation.override.invalid
@@ -60,9 +61,20 @@ class CreatesObligationOverride2 {
             myFoo.a();
         }
 
+        // this method isn't permitted, since it's also adding a new obligation
         @Override
         @CreatesObligation("this.myFoo")
         @CreatesObligation("this")
+        // :: error: creates.obligation.override.invalid
+        public void b() { }
+    }
+
+    static class Thudless extends Thud {
+        // this method override is also NOT permitted, because the @CreatesObligation("this.myFoo") annotation
+        // from Thud is inherited!
+        @Override
+        @CreatesObligation("this")
+        // :: error: creates.obligation.override.invalid
         public void b() { }
     }
 
@@ -140,6 +152,27 @@ class CreatesObligationOverride2 {
     static void test11() {
         // :: error: required.method.not.called
         Thud foo = new Thud();
+        foo.a();
+        foo.b();
+    }
+
+    static void test12() {
+        // :: error: required.method.not.called
+        Foo foo = new Thudless();
+        foo.a();
+        foo.b();
+    }
+
+    static void test13() {
+        // :: error: required.method.not.called
+        Thud foo = new Thudless();
+        foo.a();
+        foo.b();
+    }
+
+    static void test14() {
+        // :: error: required.method.not.called
+        Thudless foo = new Thudless();
         foo.a();
         foo.b();
     }


### PR DESCRIPTION
This change will, I hope, fix #368. It doesn't address the problem directly, because I realized that the real issue behind #368 is that `run()` is overridden to add an `@CreatesObligation` annotation, but it could be dynamically-dispatched to by an object of static type `Runnable` but that is dynamically the anonymous class we defined. This problem isn't unique to anonymous classes; you'll see in the test cases that I was able to trigger the unsoundness without needing one.

I'm not convinced that my solution is great: I've restricted the places where `@CreatesObligation` can be written by adding a new kind of error that's issued when a method with fewer `@CreatesObligation` targets is overridden by one with more. Note that because `@CreatesObligation` is inheritable, in practice this means that it's only permitted to write a new obligation annotation on a method that isn't overriding anything. I think that's not too restrictive of a requirement, but I'm curious what you all think.