### PR TITLE
Fixed handling of ternary expressions

### DIFF
--- a/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
+++ b/object-construction-checker/tests/mustcall/ACRegularExitPointTest.java
@@ -330,8 +330,6 @@ class ACRegularExitPointTest {
         Foo ternary3 = b ? new Foo() : x;
         ternary3.a();
 
-        // This is a false positive
-        // :: error: required.method.not.called
         Foo y = new Foo();
         Foo ternary4 = b ? y : y;
         ternary4.a();

--- a/object-construction-checker/tests/mustcall/SelfAssign.java
+++ b/object-construction-checker/tests/mustcall/SelfAssign.java
@@ -17,15 +17,14 @@ class SelfAssign {
 
   }
 
-  // this case still needs to be handled
-//  static void test1(boolean b) throws IOException {
-//    InputStream selfAssignIn = new FileInputStream("file.txt");
-//    try {
-//      selfAssignIn = selfAssignIn.markSupported()? selfAssignIn: new BufferedInputStream(selfAssignIn);
-//    } finally {
-//      selfAssignIn.close();
-//    }
-//  }
+  static void test1(boolean b) throws IOException {
+    InputStream selfAssignIn = new FileInputStream("file.txt");
+    try {
+      selfAssignIn = selfAssignIn.markSupported()? selfAssignIn: new BufferedInputStream(selfAssignIn);
+    } finally {
+      selfAssignIn.close();
+    }
+  }
 
   static void test2(boolean b) throws IOException {
     InputStream in = new FileInputStream("file.txt");


### PR DESCRIPTION
This is a cleaner and more correct handling of ternary expressions in `MustCallInvokedChecker`.  In short, we now properly leverage the representation of ternary expressions in the Checker Framework CFG to handle each case separately.  See `SelfAssign.test1()` for a case we can handle now (based on real code in HBase) that we couldn't handle before.  This also re-uses the cleaned-up logic for assignments from #377.  I tried to add sufficient documentation to make the logic clear.