### PR TITLE
When checking re-assignment to a field, get the called methods type from the store before evaluating the RHS

### DIFF
--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -679,7 +679,6 @@ class MustCallInvokedChecker {
    *
    * @param node an assignment to a non-final, owning field
    * @param newDefs
-   * @param rhs
    */
   private void checkReassignmentToField(
       AssignmentNode node, Set<ImmutableSet<LocalVarWithTree>> newDefs) {

--- a/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
+++ b/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/MustCallInvokedChecker.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -732,7 +733,11 @@ class MustCallInvokedChecker {
       return;
     }
 
+    typeFactory.getAnnotatedType(lhsNode.getTree());
+    System.out.println("checking that a non-final owning field is not overwritten");
     CFStore cmStoreBefore = typeFactory.getStoreBefore(node);
+    System.out.println("cmStoreBefore: " + cmStoreBefore);
+    System.out.println("gat on the field: " + typeFactory.getAnnotatedType(lhsNode.getTree()));
     CFValue cmValue = cmStoreBefore == null ? null : cmStoreBefore.getValue(lhs);
     AnnotationMirror cmAnno =
         cmValue == null
@@ -744,6 +749,9 @@ class MustCallInvokedChecker {
                             anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods"))
                 .findAny()
                 .orElse(typeFactory.top);
+
+    System.out.println("cmAnno: " + cmAnno);
+    System.out.println("mcValues: " + String.join(", ", mcValues));
 
     if (!calledMethodsSatisfyMustCall(mcValues, cmAnno)) {
       Element lhsElement = TreeUtils.elementFromTree(lhs.getTree());

--- a/object-construction-checker/tests/mustcall/SocketField.java
+++ b/object-construction-checker/tests/mustcall/SocketField.java
@@ -1,0 +1,25 @@
+// test case for https://github.com/kelloggm/object-construction-checker/issues/381
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.objectconstruction.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+import java.net.Socket;
+import java.io.IOException;
+
+@MustCall("closeSocket")
+class SocketField {
+    protected @Owning Socket socket = null;
+
+    @CreatesObligation("this")
+    protected void setupConnection(javax.net.SocketFactory socketFactory) throws IOException {
+        this.socket.close();
+        //this.socket = new Socket();
+        @CalledMethods("close") Socket s = this.socket;
+        this.socket = socketFactory.createSocket();
+    }
+    @EnsuresCalledMethods(value = "this.socket", methods = "close")
+    private void closeSocket() throws IOException {
+        this.socket.close();
+    }
+}

--- a/object-construction-checker/tests/mustcall/SocketField.java
+++ b/object-construction-checker/tests/mustcall/SocketField.java
@@ -4,6 +4,8 @@ import org.checkerframework.checker.mustcall.qual.*;
 import org.checkerframework.checker.objectconstruction.qual.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 
+import org.checkerframework.dataflow.qual.Pure;
+
 import java.net.Socket;
 import java.io.IOException;
 
@@ -13,11 +15,48 @@ class SocketField {
 
     @CreatesObligation("this")
     protected void setupConnection(javax.net.SocketFactory socketFactory) throws IOException {
+        // This is the original test case. Before this issue was fixed, an error was issued on the second line.
         this.socket.close();
-        //this.socket = new Socket();
+        this.socket = socketFactory.createSocket();
+    }
+
+    @CreatesObligation("this")
+    protected void setupConnectionWithLocal(javax.net.SocketFactory socketFactory) throws IOException {
+        // This is the original test case, modified to include an assignment to a local that demonstrates that
+        // the correct value was in the store at some point.
+        this.socket.close();
         @CalledMethods("close") Socket s = this.socket;
         this.socket = socketFactory.createSocket();
     }
+
+    @CreatesObligation("this")
+    protected void setupConnectionWithConstructor(javax.net.SocketFactory socketFactory) throws IOException {
+        // This is the original test case, modified to replace the call to createSocket() with a new Socket() call.
+        // This version succeeded, even before the bug was fixed.
+        this.socket.close();
+        this.socket = new Socket();
+    }
+
+    @CreatesObligation("this")
+    protected void setupConnection2(javax.net.SocketFactory socketFactory) throws IOException {
+        this.socket.close();
+        // This version succeeds, because getSocket is @Pure, so no side-effects can occur.
+        this.socket = getSocket(socketFactory);
+    }
+
+    @CreatesObligation("this")
+    protected void setupConnection3(javax.net.SocketFactory socketFactory) throws IOException {
+        // This version demonstrates a work-around.
+        Socket s = socketFactory.createSocket();
+        this.socket.close();
+        this.socket = s;
+    }
+
+    @Pure
+    private Socket getSocket(javax.net.SocketFactory socketFactory) throws IOException {
+        return socketFactory.createSocket();
+    }
+
     @EnsuresCalledMethods(value = "this.socket", methods = "close")
     private void closeSocket() throws IOException {
         this.socket.close();


### PR DESCRIPTION
fixes #381. Previously, we got the called methods type from the store before the assignment node, which is after the RHS in the CFG (and therefore can have its store affected by side-effects from evaluating the RHS).