### PR TITLE
Clean builds for plume util

### DIFF
--- a/experimental-machinery/ablation/run-always-call-on-plume-util.sh
+++ b/experimental-machinery/ablation/run-always-call-on-plume-util.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 cd plume-util
-./gradlew compileJava
+# do a clean build since we always want full output from tool
+./gradlew clean compileJava


### PR DESCRIPTION
I think for the purposes of an artifact / experiment scripts, we should always do a clean build of `plume-util`.  I observed in the Docker container that sometimes the compilation doesn't run at all when running `run-always-call-on-plume-util.sh` since it ran already, which is good for the development process but could be surprising to someone trying to run our experiment scripts.